### PR TITLE
Fix/issue 39 requirement for node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
       "pre-push": "npm run lint",
       "commit-msg": "commitlint --config config/commitlint.config.js -E HUSKY_GIT_PARAMS"
     }
+  },
+  "engines": {
+    "node": ">=10.0 <12.0"
   }
 }

--- a/packages/element-lib/package.json
+++ b/packages/element-lib/package.json
@@ -82,5 +82,8 @@
     "jest": "^24.5.0",
     "jsonwebtoken": "^8.5.1",
     "truffle": "^5.0.8"
+  },
+  "engines": {
+    "node": ">=10.0 <12.0"
   }
 }


### PR DESCRIPTION
fixes #39 

Node < 10 doesn't work because the crypto library doesn't suppport it
Node >= 12 doesn't work because truffle doesn't support it