### PR TITLE
Optimize sync

### DIFF
--- a/packages/element-api/src/express/routes/sidetree/index.js
+++ b/packages/element-api/src/express/routes/sidetree/index.js
@@ -77,9 +77,13 @@ router.post('/requests', async (req, res, next) => {
  */
 router.get('/docs', async (req, res, next) => {
   try {
-    const result = await req.app
-      .get('sidetree')
-      .db.readCollection('element:sidetree:did:documentRecord');
+    const sidetree = req.app.get('sidetree');
+    const currentTime = await sidetree.blockchain.getCurrentTime();
+    const toTransactionTime = currentTime.time;
+    const lastSync = await sidetree.db.read('element:sidetree:sync');
+    const fromTransactionTime = lastSync.syncStopDateTime ? lastSync.lastTransactionTime : 0;
+    await sidetree.sync({ fromTransactionTime, toTransactionTime });
+    const result = await sidetree.db.readCollection('element:sidetree:did:documentRecord');
     res.status(200).json(result);
   } catch (e) {
     next(e);

--- a/packages/element-api/src/express/routes/sidetree/index.js
+++ b/packages/element-api/src/express/routes/sidetree/index.js
@@ -78,11 +78,7 @@ router.post('/requests', async (req, res, next) => {
 router.get('/docs', async (req, res, next) => {
   try {
     const sidetree = req.app.get('sidetree');
-    const currentTime = await sidetree.blockchain.getCurrentTime();
-    const toTransactionTime = currentTime.time;
-    const lastSync = await sidetree.db.read('element:sidetree:sync');
-    const fromTransactionTime = lastSync.syncStopDateTime ? lastSync.lastTransactionTime : 0;
-    await sidetree.sync({ fromTransactionTime, toTransactionTime });
+    await sidetree.sync();
     const result = await sidetree.db.readCollection('element:sidetree:did:documentRecord');
     res.status(200).json(result);
   } catch (e) {

--- a/packages/element-lib/src/adapters/blockchain/ethereum/index.js
+++ b/packages/element-lib/src/adapters/blockchain/ethereum/index.js
@@ -158,17 +158,8 @@ class EthereumBlockchain {
     };
   }
 
-  // TODO
   async getCurrentTime() {
-    const block = await new Promise((resolve, reject) => {
-      this.web3.eth.getBlock('latest', (err, data) => {
-        if (err) {
-          return reject(err);
-        }
-        return resolve(data);
-      });
-    });
-    return this.getBlockchainTime(block.number);
+    return this.getBlockchainTime('latest');
   }
 
   async write(anchorFileHash) {

--- a/packages/element-lib/src/adapters/blockchain/ethereum/index.js
+++ b/packages/element-lib/src/adapters/blockchain/ethereum/index.js
@@ -158,6 +158,7 @@ class EthereumBlockchain {
     };
   }
 
+  // TODO
   async getCurrentTime() {
     const block = await new Promise((resolve, reject) => {
       this.web3.eth.getBlock('latest', (err, data) => {

--- a/packages/element-lib/src/adapters/database/ElementRXDBAdapter.js
+++ b/packages/element-lib/src/adapters/database/ElementRXDBAdapter.js
@@ -51,6 +51,7 @@ class ElementRXDBAdapter {
           operations: {},
           syncStartDateTime: {},
           syncStopDateTime: {},
+          lastTransactionTime: {},
         },
       },
     });

--- a/packages/element-lib/src/sidetree/Sidetree.js
+++ b/packages/element-lib/src/sidetree/Sidetree.js
@@ -23,6 +23,7 @@ class Sidetree {
     require('./batchRequests')(this);
     require('./resolve')(this);
     require('./sync')(this);
+    require('./syncTransaction')(this);
     require('./getNodeInfo')(this);
     require('./getTransactionSummary')(this);
     this.op = require('./op');

--- a/packages/element-lib/src/sidetree/serviceBus/sync.js
+++ b/packages/element-lib/src/sidetree/serviceBus/sync.js
@@ -22,7 +22,6 @@ module.exports = (sidetree) => {
         if (!valid) {
           return sidetree.serviceBus.emit('element:sidetree:error:badTransaction', { transaction });
         }
-        // TODO: sync if not already synced
         return sidetree.syncTransaction({ transaction });
       });
       await Promise.all(transactionPromises);

--- a/packages/element-lib/src/sidetree/serviceBus/sync.js
+++ b/packages/element-lib/src/sidetree/serviceBus/sync.js
@@ -8,8 +8,6 @@ module.exports = (sidetree) => {
     'element:sidetree:sync:start',
     async ({ fromTransactionTime, toTransactionTime }) => {
       const syncStartDateTime = moment().toISOString();
-      // console.log('begin sync: ', syncStartDateTime);
-
       await sidetree.db.write('element:sidetree:sync', {
         type: 'element:sidetree:sync',
         syncStartDateTime,
@@ -42,88 +40,58 @@ module.exports = (sidetree) => {
 
       const anchorFile = await sidetree.getAnchorFile(transaction.anchorFileHash);
       if (anchorFile) {
-        return sidetree.serviceBus.emit('element:sidetree:sync:anchorFile', {
-          transaction,
-          anchorFile,
-          toTransactionTime,
-        });
+        const batchFile = await sidetree.getBatchFile(anchorFile.batchFileHash);
+        if (batchFile) {
+          const operations = batchFileToOperations(batchFile);
+          const anchoredOperations = operations.map(operation => ({ operation, transaction }));
+          const cachedPromises = anchoredOperations.map(async op => sidetree.db.write(`element:sidetree:operation:${op.operation.operationHash}`, {
+            type: 'element:sidetree:operation',
+            transaction: op.transaction,
+            operation: op.operation,
+          }));
+
+          await Promise.all(cachedPromises);
+
+          // handle breaking protocol change.
+          if (anchorFile.didUniqueSuffixes) {
+            await Promise.all(
+              anchorFile.didUniqueSuffixes.map(async (uid) => {
+                let updatedState = {};
+                const cachedRecord = await sidetree.db.read(`element:sidetree:did:elem:${uid}`);
+                if (cachedRecord && cachedRecord.record) {
+                  updatedState = cachedRecord.record;
+                }
+                // eslint-disable-next-line
+                for (const anchoredOperation of anchoredOperations) {
+                  // eslint-disable-next-line
+                  updatedState = { ...(await reducer(updatedState, anchoredOperation, sidetree)) };
+                }
+
+                const record = updatedState[uid];
+                if (record) {
+                  await sidetree.db.write(`element:sidetree:did:elem:${uid}`, {
+                    type: 'element:sidetree:did:documentRecord',
+                    record,
+                  });
+                }
+              }),
+            );
+          }
+
+          if (transaction.transactionTime === toTransactionTime) {
+            sidetree.serviceBus.emit('element:sidetree:sync:stop', {
+              syncStopDateTime: moment().toISOString(),
+              lastTransactionTime: toTransactionTime,
+            });
+          }
+        }
+        return null;
       }
       return null;
-    },
-  );
-
-  sidetree.serviceBus.on(
-    'element:sidetree:sync:anchorFile',
-    async ({ transaction, anchorFile, toTransactionTime }) => {
-      const batchFile = await sidetree.getBatchFile(anchorFile.batchFileHash);
-      if (batchFile) {
-        return sidetree.serviceBus.emit('element:sidetree:sync:batchFile', {
-          transaction,
-          anchorFile,
-          batchFile,
-          toTransactionTime,
-        });
-      }
-      return null;
-    },
-  );
-
-  sidetree.serviceBus.on(
-    'element:sidetree:sync:batchFile',
-    async ({
-      transaction, anchorFile, batchFile, toTransactionTime,
-    }) => {
-      const operations = batchFileToOperations(batchFile);
-      const anchoredOperations = operations.map(operation => ({
-        operation,
-        transaction,
-      }));
-
-      await Promise.all(
-        anchoredOperations.map(async op => sidetree.db.write(`element:sidetree:operation:${op.operation.operationHash}`, {
-          type: 'element:sidetree:operation',
-          transaction: op.transaction,
-          operation: op.operation,
-        })),
-      );
-
-      // handle breaking protocol change.
-      if (anchorFile.didUniqueSuffixes) {
-        await Promise.all(
-          anchorFile.didUniqueSuffixes.map(async (uid) => {
-            let updatedState = {};
-            const cachedRecord = await sidetree.db.read(`element:sidetree:did:elem:${uid}`);
-            if (cachedRecord && cachedRecord.record) {
-              updatedState = cachedRecord.record;
-            }
-            // eslint-disable-next-line
-            for (const anchoredOperation of anchoredOperations) {
-              // eslint-disable-next-line
-              updatedState = { ...(await reducer(updatedState, anchoredOperation, sidetree)) };
-            }
-
-            const record = updatedState[uid];
-            if (record) {
-              await sidetree.db.write(`element:sidetree:did:elem:${uid}`, {
-                type: 'element:sidetree:did:documentRecord',
-                record,
-              });
-            }
-          }),
-        );
-      }
-
-      if (transaction.transactionTime === toTransactionTime) {
-        sidetree.serviceBus.emit('element:sidetree:sync:stop', {
-          syncStopDateTime: moment().toISOString(),
-          lastTransactionTime: toTransactionTime,
-        });
-      }
     },
   );
 
   sidetree.serviceBus.on('element:sidetree:sync:stop', async ({ syncStopDateTime }) => {
-    // console.log('end sync: ', syncStopDateTime);
     await sidetree.db.write('element:sidetree:sync', {
       type: 'element:sidetree:sync',
       syncStopDateTime,

--- a/packages/element-lib/src/sidetree/serviceBus/sync.js
+++ b/packages/element-lib/src/sidetree/serviceBus/sync.js
@@ -1,7 +1,5 @@
 const moment = require('moment');
 const schema = require('../../schema');
-const batchFileToOperations = require('../../func/batchFileToOperations');
-const reducer = require('../../reducer');
 
 module.exports = (sidetree) => {
   sidetree.serviceBus.on(
@@ -17,84 +15,34 @@ module.exports = (sidetree) => {
         fromTransactionTime,
         toTransactionTime,
       );
-      return transactions.map((transaction) => {
+      console.log(transactions.length);
+      const transactionPromises = transactions.map((transaction) => {
         const valid = schema.validator.isValid(transaction, schema.schemas.sidetreeTransaction);
         if (!valid) {
           return sidetree.serviceBus.emit('element:sidetree:error:badTransaction', { transaction });
         }
-        return sidetree.serviceBus.emit('element:sidetree:sync:transaction', {
-          transaction,
-          toTransactionTime,
-        });
+        // TODO: sync if not already synced
+        return sidetree.syncTransaction({ transaction });
+      });
+      // This is where we would add a load balancer if we ever consider use several workers
+      // to make the sync process faster
+      await Promise.all(transactionPromises);
+
+      sidetree.serviceBus.emit('element:sidetree:sync:stop', {
+        syncStopDateTime: moment().toISOString(),
+        lastTransactionTime: toTransactionTime,
       });
     },
   );
 
   sidetree.serviceBus.on(
-    'element:sidetree:sync:transaction',
-    async ({ transaction, toTransactionTime }) => {
-      await sidetree.db.write(`element:sidetree:transaction:${transaction.transactionTimeHash}`, {
-        type: 'element:sidetree:transaction',
-        ...transaction,
+    'element:sidetree:sync:stop',
+    async ({ syncStopDateTime, lastTransactionTime }) => {
+      await sidetree.db.write('element:sidetree:sync', {
+        type: 'element:sidetree:sync',
+        syncStopDateTime,
+        lastTransactionTime,
       });
-
-      const anchorFile = await sidetree.getAnchorFile(transaction.anchorFileHash);
-      if (anchorFile) {
-        const batchFile = await sidetree.getBatchFile(anchorFile.batchFileHash);
-        if (batchFile) {
-          const operations = batchFileToOperations(batchFile);
-          const anchoredOperations = operations.map(operation => ({ operation, transaction }));
-          const cachedPromises = anchoredOperations.map(async op => sidetree.db.write(`element:sidetree:operation:${op.operation.operationHash}`, {
-            type: 'element:sidetree:operation',
-            transaction: op.transaction,
-            operation: op.operation,
-          }));
-
-          await Promise.all(cachedPromises);
-
-          // handle breaking protocol change.
-          if (anchorFile.didUniqueSuffixes) {
-            await Promise.all(
-              anchorFile.didUniqueSuffixes.map(async (uid) => {
-                let updatedState = {};
-                const cachedRecord = await sidetree.db.read(`element:sidetree:did:elem:${uid}`);
-                if (cachedRecord && cachedRecord.record) {
-                  updatedState = cachedRecord.record;
-                }
-                // eslint-disable-next-line
-                for (const anchoredOperation of anchoredOperations) {
-                  // eslint-disable-next-line
-                  updatedState = { ...(await reducer(updatedState, anchoredOperation, sidetree)) };
-                }
-
-                const record = updatedState[uid];
-                if (record) {
-                  await sidetree.db.write(`element:sidetree:did:elem:${uid}`, {
-                    type: 'element:sidetree:did:documentRecord',
-                    record,
-                  });
-                }
-              }),
-            );
-          }
-
-          if (transaction.transactionTime === toTransactionTime) {
-            sidetree.serviceBus.emit('element:sidetree:sync:stop', {
-              syncStopDateTime: moment().toISOString(),
-              lastTransactionTime: toTransactionTime,
-            });
-          }
-        }
-        return null;
-      }
-      return null;
     },
   );
-
-  sidetree.serviceBus.on('element:sidetree:sync:stop', async ({ syncStopDateTime }) => {
-    await sidetree.db.write('element:sidetree:sync', {
-      type: 'element:sidetree:sync',
-      syncStopDateTime,
-    });
-  });
 };

--- a/packages/element-lib/src/sidetree/serviceBus/sync.js
+++ b/packages/element-lib/src/sidetree/serviceBus/sync.js
@@ -15,7 +15,6 @@ module.exports = (sidetree) => {
         fromTransactionTime,
         toTransactionTime,
       );
-      console.log(transactions.length);
       const transactionPromises = transactions.map((transaction) => {
         const valid = schema.validator.isValid(transaction, schema.schemas.sidetreeTransaction);
         if (!valid) {

--- a/packages/element-lib/src/sidetree/sync.js
+++ b/packages/element-lib/src/sidetree/sync.js
@@ -1,7 +1,18 @@
 module.exports = async (sidetree) => {
   // eslint-disable-next-line
-  sidetree.sync = async ({ fromTransactionTime, toTransactionTime }) => {
+  sidetree.sync = async args => {
     // todo: if synching, don't sync....
+    let fromTransactionTime;
+    let toTransactionTime;
+
+    if (!args) {
+      const lastSync = await sidetree.db.read('element:sidetree:sync');
+      fromTransactionTime = lastSync.syncStopDateTime ? lastSync.lastTransactionTime : 0;
+      const currentTime = await sidetree.blockchain.getCurrentTime();
+      toTransactionTime = currentTime.time;
+    } else {
+      ({ fromTransactionTime, toTransactionTime } = args);
+    }
 
     sidetree.serviceBus.emit('element:sidetree:sync:start', {
       fromTransactionTime,

--- a/packages/element-lib/src/sidetree/sync.js
+++ b/packages/element-lib/src/sidetree/sync.js
@@ -7,7 +7,9 @@ module.exports = async (sidetree) => {
 
     if (!args) {
       const lastSync = await sidetree.db.read('element:sidetree:sync');
-      fromTransactionTime = lastSync.syncStopDateTime ? lastSync.lastTransactionTime : 0;
+      fromTransactionTime = lastSync && lastSync.syncStopDateTime
+        ? lastSync.lastTransactionTime
+        : 0;
       const currentTime = await sidetree.blockchain.getCurrentTime();
       toTransactionTime = currentTime.time;
     } else {

--- a/packages/element-lib/src/sidetree/syncTransaction.js
+++ b/packages/element-lib/src/sidetree/syncTransaction.js
@@ -1,0 +1,58 @@
+const batchFileToOperations = require('../func/batchFileToOperations');
+const reducer = require('../reducer');
+
+module.exports = (sidetree) => {
+  // eslint-disable-next-line
+  sidetree.syncTransaction =  async ({ transaction }) => {
+    await sidetree.db.write(`element:sidetree:transaction:${transaction.transactionTimeHash}`, {
+      type: 'element:sidetree:transaction',
+      ...transaction,
+    });
+
+    const anchorFile = await sidetree.getAnchorFile(transaction.anchorFileHash);
+    if (!anchorFile) {
+      return null;
+    }
+    const batchFile = await sidetree.getBatchFile(anchorFile.batchFileHash);
+    if (!batchFile) {
+      return null;
+    }
+    const operations = batchFileToOperations(batchFile);
+    const anchoredOperations = operations.map(operation => ({ operation, transaction }));
+    // TODO: write if not written
+    const cachedPromises = anchoredOperations.map(async op => sidetree.db.write(`element:sidetree:operation:${op.operation.operationHash}`, {
+      type: 'element:sidetree:operation',
+      transaction: op.transaction,
+      operation: op.operation,
+    }));
+
+    await Promise.all(cachedPromises);
+
+    // FIXME
+    // handle breaking protocol change.
+    if (anchorFile.didUniqueSuffixes) {
+      await Promise.all(
+        anchorFile.didUniqueSuffixes.map(async (uid) => {
+          let updatedState = {};
+          const cachedRecord = await sidetree.db.read(`element:sidetree:did:elem:${uid}`);
+          if (cachedRecord && cachedRecord.record) {
+            updatedState = cachedRecord.record;
+          }
+          // eslint-disable-next-line
+          for (const anchoredOperation of anchoredOperations) {
+            // eslint-disable-next-line
+            updatedState = { ...(await reducer(updatedState, anchoredOperation, sidetree)) };
+          }
+
+          const record = updatedState[uid];
+          if (record) {
+            await sidetree.db.write(`element:sidetree:did:elem:${uid}`, {
+              type: 'element:sidetree:did:documentRecord',
+              record,
+            });
+          }
+        }),
+      );
+    }
+  };
+};

--- a/packages/element-lib/src/sidetree/syncTransaction.js
+++ b/packages/element-lib/src/sidetree/syncTransaction.js
@@ -26,7 +26,6 @@ module.exports = (sidetree) => {
 
     await Promise.all(cachedPromises);
 
-    // FIXME
     // handle breaking protocol change.
     if (anchorFile.didUniqueSuffixes) {
       await Promise.all(

--- a/packages/element-lib/src/sidetree/syncTransaction.js
+++ b/packages/element-lib/src/sidetree/syncTransaction.js
@@ -18,12 +18,10 @@ module.exports = (sidetree) => {
       return null;
     }
     const operations = batchFileToOperations(batchFile);
-    const anchoredOperations = operations.map(operation => ({ operation, transaction }));
-    // TODO: write if not written
-    const cachedPromises = anchoredOperations.map(async op => sidetree.db.write(`element:sidetree:operation:${op.operation.operationHash}`, {
+    const cachedPromises = operations.map(async operation => sidetree.db.write(`element:sidetree:operation:${operation.operationHash}`, {
       type: 'element:sidetree:operation',
-      transaction: op.transaction,
-      operation: op.operation,
+      transaction,
+      operation,
     }));
 
     await Promise.all(cachedPromises);
@@ -39,9 +37,10 @@ module.exports = (sidetree) => {
             updatedState = cachedRecord.record;
           }
           // eslint-disable-next-line
-          for (const anchoredOperation of anchoredOperations) {
+          for (const operation of operations) {
+            const anchoredOperation = ({ operation, transaction });
             // eslint-disable-next-line
-            updatedState = { ...(await reducer(updatedState, anchoredOperation, sidetree)) };
+            updatedState = { ...(await reducer(updatedState, anchoredOperation , sidetree)) };
           }
 
           const record = updatedState[uid];


### PR DESCRIPTION
- Separate the "syncTransaction" logic from the rest of the sync process
- Refactor sync to have less events
- Make sync start right after the last sync if no parameters is provided
- Improve getCurrentTime so that it uses 1 RPC call instead of 2
- Add a `.sync()` call completing a /docs API call
- fix sync completion bug