### PR TITLE
Feat/mute 482 block explorer

### DIFF
--- a/packages/element-api/src/express/routes/sidetree/index.js
+++ b/packages/element-api/src/express/routes/sidetree/index.js
@@ -103,7 +103,8 @@ router.get('/docs', async (req, res, next) => {
  */
 router.get('/transactions', async (req, res, next) => {
   try {
-    const result = await req.app.get('sidetree').getTransactions(req.query);
+    const sidetree = req.app.get('sidetree-v2');
+    const result = await sidetree.getTransactions(req.query);
     res.status(200).json(result);
   } catch (e) {
     next(e);

--- a/packages/element-api/src/express/routes/sidetree/index.js
+++ b/packages/element-api/src/express/routes/sidetree/index.js
@@ -104,7 +104,8 @@ router.get('/docs', async (req, res, next) => {
 router.get('/transactions', async (req, res, next) => {
   try {
     const sidetree = req.app.get('sidetree-v2');
-    const result = await sidetree.getTransactions();
+    const { limit } = req.query;
+    const result = await sidetree.getTransactions({ limit });
     res.status(200).json(result);
   } catch (e) {
     next(e);

--- a/packages/element-api/src/express/routes/sidetree/index.js
+++ b/packages/element-api/src/express/routes/sidetree/index.js
@@ -138,29 +138,6 @@ router.get('/transaction/:transactionTimeHash/summary', async (req, res, next) =
  * @swagger
  *
  * paths:
- *   "/sidetree/operations":
- *     get:
- *       description: Return all operations.
- *       tags: [Sidetree]
- *       produces:
- *       - application/json
- *       responses:
- *         '200':
- *           description: sidetree operations.
- */
-router.get('/operations', async (req, res, next) => {
-  try {
-    const result = await req.app.get('sidetree').getOperations();
-    res.status(200).json(result);
-  } catch (e) {
-    next(e);
-  }
-});
-
-/**
- * @swagger
- *
- * paths:
  *   "/sidetree/operations/{didUniqueSuffix}":
  *     get:
  *       description: Return all operations for a didUniqueSuffix.

--- a/packages/element-api/src/express/routes/sidetree/index.js
+++ b/packages/element-api/src/express/routes/sidetree/index.js
@@ -128,7 +128,8 @@ router.get('/transactions', async (req, res, next) => {
 router.get('/transaction/:transactionTimeHash/summary', async (req, res, next) => {
   try {
     const { transactionTimeHash } = req.params;
-    const result = await req.app.get('sidetree').getTransactionSummary(transactionTimeHash);
+    const sidetree = req.app.get('sidetree-v2');
+    const result = await sidetree.getTransactionSummary(transactionTimeHash);
     res.status(200).json(result);
   } catch (e) {
     next(e);

--- a/packages/element-api/src/express/routes/sidetree/index.js
+++ b/packages/element-api/src/express/routes/sidetree/index.js
@@ -104,7 +104,7 @@ router.get('/docs', async (req, res, next) => {
 router.get('/transactions', async (req, res, next) => {
   try {
     const sidetree = req.app.get('sidetree-v2');
-    const result = await sidetree.getTransactions(req.query);
+    const result = await sidetree.getTransactions();
     res.status(200).json(result);
   } catch (e) {
     next(e);

--- a/packages/element-api/src/express/routes/sidetree/requests.spec.js
+++ b/packages/element-api/src/express/routes/sidetree/requests.spec.js
@@ -35,11 +35,6 @@ describe('sidetree', () => {
     expect(res.body.id).toBe(actor.did);
   });
 
-  it('operations', async () => {
-    res = await server.get('/api/v1/sidetree/operations').set('Accept', 'application/json');
-    expect(res.body.length).toBeDefined();
-  });
-
   it('docs', async () => {
     res = await server.get('/api/v1/sidetree/docs').set('Accept', 'application/json');
     expect(res.body.length).toBeDefined();

--- a/packages/element-app/src/components/Pages/DIDListPage/DIDListPage.js
+++ b/packages/element-app/src/components/Pages/DIDListPage/DIDListPage.js
@@ -30,8 +30,7 @@ export class DIDListPage extends Component {
                 <DIDListItem
                   record={dr.record}
                   onClick={(item) => {
-                    // FIXME
-                    this.props.history.push(`/server/transactions/${item.lastTransaction.transactionTimeHash}`);
+                    this.props.history.push(`/server/transactions/${item.lastTransaction.transactionHash}`);
                   }}
                 />
               </div>

--- a/packages/element-app/src/components/Pages/DIDListPage/DIDListPage.js
+++ b/packages/element-app/src/components/Pages/DIDListPage/DIDListPage.js
@@ -30,6 +30,7 @@ export class DIDListPage extends Component {
                 <DIDListItem
                   record={dr.record}
                   onClick={(item) => {
+                    // FIXME
                     this.props.history.push(`/server/transactions/${item.lastTransaction.transactionTimeHash}`);
                   }}
                 />

--- a/packages/element-app/src/components/Pages/ExplorerPage/ExplorerPage.js
+++ b/packages/element-app/src/components/Pages/ExplorerPage/ExplorerPage.js
@@ -3,21 +3,12 @@ import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
 import LinearProgress from '@material-ui/core/LinearProgress';
-
 import { Pages } from '../../index';
-
 import { SidetreeTransaction } from '../../SidetreeTransaction';
 
 export class ExplorerPage extends Component {
   componentWillMount() {
-    const searchParams = new URLSearchParams(window.location.search);
-    const since = searchParams.get('since');
-    const transactionTimeHash = searchParams.get('transaction-time-hash');
-    if (since && transactionTimeHash) {
-      this.props.getSidetreeTransactions({ since, transactionTimeHash });
-    } else {
-      this.props.getSidetreeTransactions();
-    }
+    this.props.getSidetreeTransactions();
   }
 
   render() {

--- a/packages/element-app/src/components/Pages/ExplorerPage/ExplorerPage.js
+++ b/packages/element-app/src/components/Pages/ExplorerPage/ExplorerPage.js
@@ -37,7 +37,7 @@ export class ExplorerPage extends Component {
                   transaction={transaction}
                   blockchain={'Ethereum'}
                   network={'ropsten'}
-                  onClickTransactionTimeHash={(transactionHash) => {
+                  onClick={(transactionHash) => {
                     this.props.history.push(`/server/transactions/${transactionHash}`);
                   }}
                 />

--- a/packages/element-app/src/components/Pages/ExplorerPage/ExplorerPage.js
+++ b/packages/element-app/src/components/Pages/ExplorerPage/ExplorerPage.js
@@ -8,7 +8,8 @@ import { SidetreeTransaction } from '../../SidetreeTransaction';
 
 export class ExplorerPage extends Component {
   componentWillMount() {
-    this.props.getSidetreeTransactions();
+    // Only get the last 20 transactions to avoid crashing the page
+    this.props.getSidetreeTransactions({ limit: 20 });
   }
 
   render() {

--- a/packages/element-app/src/components/Pages/ExplorerPage/ExplorerPage.js
+++ b/packages/element-app/src/components/Pages/ExplorerPage/ExplorerPage.js
@@ -37,8 +37,8 @@ export class ExplorerPage extends Component {
                   transaction={transaction}
                   blockchain={'Ethereum'}
                   network={'ropsten'}
-                  onClickTransactionTimeHash={(transactionTimeHash) => {
-                    this.props.history.push(`/server/transactions/${transactionTimeHash}`);
+                  onClickTransactionTimeHash={(transactionHash) => {
+                    this.props.history.push(`/server/transactions/${transactionHash}`);
                   }}
                 />
               </Grid>

--- a/packages/element-app/src/components/Pages/ExplorerTransactionPage/ExplorerTransactionPage.js
+++ b/packages/element-app/src/components/Pages/ExplorerTransactionPage/ExplorerTransactionPage.js
@@ -53,6 +53,7 @@ export class ExplorerTransactionPage extends Component {
                   batchFileHash={sidetreeTransactionSummary.anchorFile.batchFileHash}
                   batchFile={sidetreeTransactionSummary.batchFile}
                   operations={sidetreeTransactionSummary.operations}
+                  transaction={sidetreeTransactionSummary.transaction}
                   expanded={true}
                 />
               </React.Fragment>

--- a/packages/element-app/src/components/Pages/ExplorerTransactionPage/ExplorerTransactionPage.js
+++ b/packages/element-app/src/components/Pages/ExplorerTransactionPage/ExplorerTransactionPage.js
@@ -13,7 +13,7 @@ import { SidetreeBatchFile } from '../../SidetreeBatchFile';
 export class ExplorerTransactionPage extends Component {
   componentWillMount() {
     this.props.getSidetreeOperationsFromTransactionTimeHash(
-      this.props.match.params.transactionTimeHash,
+      this.props.match.params.transactionHash,
     );
   }
 

--- a/packages/element-app/src/components/Pages/ExplorerTransactionPage/ExplorerTransactionPage.js
+++ b/packages/element-app/src/components/Pages/ExplorerTransactionPage/ExplorerTransactionPage.js
@@ -12,7 +12,7 @@ import { SidetreeBatchFile } from '../../SidetreeBatchFile';
 
 export class ExplorerTransactionPage extends Component {
   componentWillMount() {
-    this.props.getSidetreeOperationsFromTransactionTimeHash(
+    this.props.getSidetreeOperationsFromTransactionHash(
       this.props.match.params.transactionHash,
     );
   }
@@ -67,7 +67,7 @@ export class ExplorerTransactionPage extends Component {
 
 ExplorerTransactionPage.propTypes = {
   nodeStore: PropTypes.object.isRequired,
-  getSidetreeOperationsFromTransactionTimeHash: PropTypes.func.isRequired,
+  getSidetreeOperationsFromTransactionHash: PropTypes.func.isRequired,
   match: PropTypes.object.isRequired,
   history: PropTypes.object.isRequired,
 };

--- a/packages/element-app/src/components/SidetreeBatchFile/SidetreeBatchFile.js
+++ b/packages/element-app/src/components/SidetreeBatchFile/SidetreeBatchFile.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-
 import Grid from '@material-ui/core/Grid/Grid';
 import Typography from '@material-ui/core/Typography/Typography';
 import ExpansionPanel from '@material-ui/core/ExpansionPanel/ExpansionPanel';
@@ -9,7 +8,6 @@ import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails/Expan
 import Avatar from '@material-ui/core/Avatar';
 import VerifiedUser from '@material-ui/icons/VerifiedUser';
 import ExpandMore from '@material-ui/icons/ExpandMore';
-
 import { SidetreeOperation } from '../SidetreeOperation';
 
 export class SidetreeBatchFile extends Component {

--- a/packages/element-app/src/components/SidetreeBatchFile/SidetreeBatchFile.js
+++ b/packages/element-app/src/components/SidetreeBatchFile/SidetreeBatchFile.js
@@ -24,8 +24,7 @@ export class SidetreeBatchFile extends Component {
   }
 
   render() {
-    const { batchFileHash, operations } = this.props;
-
+    const { batchFileHash, operations, transaction } = this.props;
     const { expanded } = this.state;
 
     return (
@@ -58,8 +57,8 @@ export class SidetreeBatchFile extends Component {
         </ExpansionPanelSummary>
         <ExpansionPanelDetails style={{ flexDirection: 'column' }}>
           {operations.map(op => (
-            <React.Fragment key={op.operation.operationHash}>
-              <SidetreeOperation operation={op} expanded={true} />
+            <React.Fragment key={op.operationHash}>
+              <SidetreeOperation operation={{ operation: op, transaction }} expanded={true} />
             </React.Fragment>
           ))}
         </ExpansionPanelDetails>
@@ -72,6 +71,7 @@ SidetreeBatchFile.propTypes = {
   batchFileHash: PropTypes.string.isRequired,
   batchFile: PropTypes.object.isRequired,
   operations: PropTypes.array.isRequired,
+  transaction: PropTypes.object.isRequired,
   expanded: PropTypes.bool,
 };
 

--- a/packages/element-app/src/components/SidetreeBatchFile/SidetreeBatchFile.stories.js
+++ b/packages/element-app/src/components/SidetreeBatchFile/SidetreeBatchFile.stories.js
@@ -45,6 +45,7 @@ const operations = [
 const transaction = {
   transactionTime: 6427949,
   transactionTimeHash: '0x9352a467034a7a3ea07d696c8fe1d3b573b9d60850ed585e6a597a1dfee8c915',
+  transactionHash: '0x2715962aab0228ac2cd2a4d13fbfe023e2c3632e8a0b536648dd8e2cf8600c39',
   transactionNumber: 416,
   anchorFileHash: 'QmSoAXE8aFuzhw1Fjdy7dW6kEPE31u4Cduub5ZKaFqwmvQ',
   transactionTimestamp: 1569024138,

--- a/packages/element-app/src/components/SidetreeBatchFile/SidetreeBatchFile.stories.js
+++ b/packages/element-app/src/components/SidetreeBatchFile/SidetreeBatchFile.stories.js
@@ -39,15 +39,16 @@ const operations = [
         ],
       },
     },
-    transaction: {
-      transactionTime: 6427949,
-      transactionTimeHash: '0x9352a467034a7a3ea07d696c8fe1d3b573b9d60850ed585e6a597a1dfee8c915',
-      transactionNumber: 416,
-      anchorFileHash: 'QmSoAXE8aFuzhw1Fjdy7dW6kEPE31u4Cduub5ZKaFqwmvQ',
-      transactionTimestamp: 1569024138,
-    },
   },
 ];
+
+const transaction = {
+  transactionTime: 6427949,
+  transactionTimeHash: '0x9352a467034a7a3ea07d696c8fe1d3b573b9d60850ed585e6a597a1dfee8c915',
+  transactionNumber: 416,
+  anchorFileHash: 'QmSoAXE8aFuzhw1Fjdy7dW6kEPE31u4Cduub5ZKaFqwmvQ',
+  transactionTimestamp: 1569024138,
+};
 
 storiesOf('Sidetree', module).add('Batch File', () => (
   <div>
@@ -55,6 +56,7 @@ storiesOf('Sidetree', module).add('Batch File', () => (
       batchFileHash={'QmSXdFQsKWRS6qJLSDgjAG7SLsFfiwJkDK5NDyUScVEjjo'}
       batchFile={batchFile}
       operations={operations}
+      transaction={transaction}
     />
   </div>
 ));

--- a/packages/element-app/src/components/SidetreeOperation/SidetreeOperation.js
+++ b/packages/element-app/src/components/SidetreeOperation/SidetreeOperation.js
@@ -49,14 +49,13 @@ class SidetreeOperation extends Component {
   }
 
   render() {
-    const { operation, classes } = this.props;
+    const { operation: { operation, transaction }, classes } = this.props;
     const { expanded } = this.state;
-
-    const { decodedOperationPayload } = operation.operation;
-    const { transactionTimestamp } = operation.transaction;
-    const header = operation.operation.decodedHeader;
+    const { decodedOperationPayload } = operation;
+    const { transactionTimestamp } = transaction;
+    const header = operation.decodedHeader;
     const { alg, kid, operation: operationName } = header;
-    const { signature } = operation.operation.decodedOperation;
+    const { signature } = operation.decodedOperation;
 
     return (
       <ExpansionPanel expanded={expanded} className={classes.expansion}>

--- a/packages/element-app/src/components/SidetreeOperation/SidetreeOperation.stories.js
+++ b/packages/element-app/src/components/SidetreeOperation/SidetreeOperation.stories.js
@@ -36,6 +36,7 @@ const operations = [
     transaction: {
       transactionTime: 6427949,
       transactionTimeHash: '0x9352a467034a7a3ea07d696c8fe1d3b573b9d60850ed585e6a597a1dfee8c915',
+      transactionHash: '0x2715962aab0228ac2cd2a4d13fbfe023e2c3632e8a0b536648dd8e2cf8600c39',
       transactionNumber: 416,
       anchorFileHash: 'QmSoAXE8aFuzhw1Fjdy7dW6kEPE31u4Cduub5ZKaFqwmvQ',
       transactionTimestamp: 1569024138,

--- a/packages/element-app/src/components/SidetreeTransaction/SidetreeTransaction.js
+++ b/packages/element-app/src/components/SidetreeTransaction/SidetreeTransaction.js
@@ -16,15 +16,16 @@ import IconButton from '@material-ui/core/IconButton';
 import DoneAll from '@material-ui/icons/DoneAll';
 import VerifiedUser from '@material-ui/icons/VerifiedUser';
 import Receipt from '@material-ui/icons/Receipt';
+import ThumbsUpDownIcon from '@material-ui/icons/ThumbsUpDown';
 import ExpandMore from '@material-ui/icons/ExpandMore';
 import Link from '@material-ui/icons/Link';
 import LocalActivity from '@material-ui/icons/LocalActivity';
 import Forward from '@material-ui/icons/Forward';
 
-const getBlockExplorerUrl = (blockHash, blockchain, network) => {
+const getBlockExplorerUrl = (suffix, blockchain, network) => {
   if (blockchain === 'Ethereum') {
     const sub = network ? `${network}.` : '';
-    return `https://${sub}etherscan.io/block/${blockHash}`;
+    return `https://${sub}etherscan.io/${suffix}`;
   }
   return '#';
 };
@@ -54,9 +55,10 @@ export class SidetreeTransaction extends Component {
 
     const { expanded } = this.state;
 
-    // TODO Add link to transaction
-    const blochHashUrl = getBlockExplorerUrl(transaction.transactionTimeHash, blockchain, network);
-    const ipfsUrl = getIpfsUrl(anchorFileBase, transaction.anchorFileHash);
+    const { transactionHash, transactionTimeHash, anchorFileHash } = transaction;
+    const blochHashUrl = getBlockExplorerUrl(`block/${transactionTimeHash}`, blockchain, network);
+    const transactionHashUrl = getBlockExplorerUrl(`tx/${transactionHash}`, blockchain, network);
+    const ipfsUrl = getIpfsUrl(anchorFileBase, anchorFileHash);
     return (
       <ExpansionPanel expanded={expanded}>
         <ExpansionPanelSummary
@@ -125,7 +127,7 @@ export class SidetreeTransaction extends Component {
                 </ListItemAvatar>
                 <ListItemText
                   style={{ wordBreak: 'break-all', marginRight: '2px' }}
-                  primary={`Block ${transaction.transactionTime}`}
+                  primary={`Ethereum Block ${transaction.transactionTime}`}
                   secondary={transaction.transactionTimeHash}
                 />
                 <ListItemSecondaryAction>
@@ -140,6 +142,28 @@ export class SidetreeTransaction extends Component {
                 </ListItemSecondaryAction>
               </ListItem>
 
+              <ListItem>
+                <ListItemAvatar>
+                  <Avatar>
+                    <ThumbsUpDownIcon />
+                  </Avatar>
+                </ListItemAvatar>
+                <ListItemText
+                  style={{ wordBreak: 'break-all', marginRight: '2px' }}
+                  primary={'Ethereum transaction' }
+                  secondary={transaction.transactionHash}
+                />
+                <ListItemSecondaryAction>
+                  <IconButton
+                    aria-label="Link"
+                    onClick={() => {
+                      window.open(transactionHashUrl);
+                    }}
+                  >
+                    <Link />
+                  </IconButton>
+                </ListItemSecondaryAction>
+              </ListItem>
               <ListItem>
                 <ListItemAvatar>
                   <Avatar>

--- a/packages/element-app/src/components/SidetreeTransaction/SidetreeTransaction.js
+++ b/packages/element-app/src/components/SidetreeTransaction/SidetreeTransaction.js
@@ -98,7 +98,7 @@ export class SidetreeTransaction extends Component {
                 </ListItemAvatar>
                 <ListItemText
                   style={{ wordBreak: 'break-all', marginRight: '2px' }}
-                  primary={`Transaction ${transaction.transactionNumber}`}
+                  primary={`Sidetree Transaction ${transaction.transactionNumber}`}
                   secondary={
                     !transaction.transactionTimestamp
                       ? ''

--- a/packages/element-app/src/components/SidetreeTransaction/SidetreeTransaction.js
+++ b/packages/element-app/src/components/SidetreeTransaction/SidetreeTransaction.js
@@ -54,6 +54,7 @@ export class SidetreeTransaction extends Component {
 
     const { expanded } = this.state;
 
+    // Add link to transaction
     const blochHashUrl = getBlockExplorerUrl(transaction.transactionTimeHash, blockchain, network);
     const ipfsUrl = getIpfsUrl(anchorFileBase, transaction.anchorFileHash);
     return (
@@ -107,7 +108,7 @@ export class SidetreeTransaction extends Component {
                     <IconButton
                       aria-label="Link"
                       onClick={() => {
-                        this.props.onClickTransactionTimeHash(transaction.transactionTimeHash);
+                        this.props.onClickTransactionTimeHash(transaction.transactionHash);
                       }}
                     >
                       <Forward />

--- a/packages/element-app/src/components/SidetreeTransaction/SidetreeTransaction.js
+++ b/packages/element-app/src/components/SidetreeTransaction/SidetreeTransaction.js
@@ -54,7 +54,7 @@ export class SidetreeTransaction extends Component {
 
     const { expanded } = this.state;
 
-    // Add link to transaction
+    // TODO Add link to transaction
     const blochHashUrl = getBlockExplorerUrl(transaction.transactionTimeHash, blockchain, network);
     const ipfsUrl = getIpfsUrl(anchorFileBase, transaction.anchorFileHash);
     return (
@@ -103,12 +103,12 @@ export class SidetreeTransaction extends Component {
                       : `${moment(transaction.transactionTimestamp * 1000).fromNow()}`
                   }
                 />
-                {this.props.onClickTransactionTimeHash && (
+                {this.props.onClick && (
                   <ListItemSecondaryAction>
                     <IconButton
                       aria-label="Link"
                       onClick={() => {
-                        this.props.onClickTransactionTimeHash(transaction.transactionHash);
+                        this.props.onClick(transaction.transactionHash);
                       }}
                     >
                       <Forward />
@@ -171,7 +171,7 @@ SidetreeTransaction.propTypes = {
   network: PropTypes.string,
   expanded: PropTypes.bool,
   anchorFileBase: PropTypes.string,
-  onClickTransactionTimeHash: PropTypes.func,
+  onClick: PropTypes.func,
 };
 
 export default SidetreeTransaction;

--- a/packages/element-app/src/components/SidetreeTransaction/SidetreeTransaction.js
+++ b/packages/element-app/src/components/SidetreeTransaction/SidetreeTransaction.js
@@ -1,14 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-
 import moment from 'moment';
-
 import Grid from '@material-ui/core/Grid/Grid';
 import Typography from '@material-ui/core/Typography/Typography';
 import ExpansionPanel from '@material-ui/core/ExpansionPanel/ExpansionPanel';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary/ExpansionPanelSummary';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails/ExpansionPanelDetails';
-
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemAvatar from '@material-ui/core/ListItemAvatar';

--- a/packages/element-app/src/components/SidetreeTransaction/SidetreeTransaction.js
+++ b/packages/element-app/src/components/SidetreeTransaction/SidetreeTransaction.js
@@ -22,10 +22,10 @@ import Link from '@material-ui/icons/Link';
 import LocalActivity from '@material-ui/icons/LocalActivity';
 import Forward from '@material-ui/icons/Forward';
 
-const getBlockExplorerUrl = (suffix, blockchain, network) => {
+const getBlockExplorerUrl = (path, hash, blockchain, network) => {
   if (blockchain === 'Ethereum') {
     const sub = network ? `${network}.` : '';
-    return `https://${sub}etherscan.io/${suffix}`;
+    return `https://${sub}etherscan.io/${path}${hash}`;
   }
   return '#';
 };
@@ -56,8 +56,8 @@ export class SidetreeTransaction extends Component {
     const { expanded } = this.state;
 
     const { transactionHash, transactionTimeHash, anchorFileHash } = transaction;
-    const blochHashUrl = getBlockExplorerUrl(`block/${transactionTimeHash}`, blockchain, network);
-    const transactionHashUrl = getBlockExplorerUrl(`tx/${transactionHash}`, blockchain, network);
+    const blochHashUrl = getBlockExplorerUrl('block/', transactionTimeHash, blockchain, network);
+    const transactionHashUrl = getBlockExplorerUrl('tx/', transactionHash, blockchain, network);
     const ipfsUrl = getIpfsUrl(anchorFileBase, anchorFileHash);
     return (
       <ExpansionPanel expanded={expanded}>

--- a/packages/element-app/src/components/SidetreeTransaction/SidetreeTransaction.stories.js
+++ b/packages/element-app/src/components/SidetreeTransaction/SidetreeTransaction.stories.js
@@ -9,6 +9,7 @@ storiesOf('SidetreeTransaction', module).add('SidetreeTransaction', () => (
       transaction={{
         transactionTime: 53,
         transactionTimeHash: '0x93e784ec47f373e8c2aa88119fc5ea586ee4d065fd72ce0e8f71c1f15efc06e0',
+        transactionHash: '0x2715962aab0228ac2cd2a4d13fbfe023e2c3632e8a0b536648dd8e2cf8600c39',
         transactionNumber: 15,
         anchorFileHash: 'QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco',
       }}
@@ -21,6 +22,7 @@ storiesOf('SidetreeTransaction', module).add('SidetreeTransaction', () => (
       transaction={{
         transactionTime: 42,
         transactionTimeHash: '0x93e784ec47f373e8c2aa88119fc5ea586ee4d065fd72ce0e8f71c1f15efc06e0',
+        transactionHash: '0x2715962aab0228ac2cd2a4d13fbfe023e2c3632e8a0b536648dd8e2cf8600c39',
         transactionNumber: 12,
         anchorFileHash: 'QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco',
       }}
@@ -32,6 +34,7 @@ storiesOf('SidetreeTransaction', module).add('SidetreeTransaction', () => (
       transaction={{
         transactionTime: 42,
         transactionTimeHash: '0x93e784ec47f373e8c2aa88119fc5ea586ee4d065fd72ce0e8f71c1f15efc06e0',
+        transactionHash: '0x2715962aab0228ac2cd2a4d13fbfe023e2c3632e8a0b536648dd8e2cf8600c39',
         transactionNumber: 12,
         anchorFileHash: 'QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco',
       }}

--- a/packages/element-app/src/index.js
+++ b/packages/element-app/src/index.js
@@ -30,7 +30,7 @@ class App extends React.Component {
                 <Route exact path="/dapp/explore" render={() => <Pages.LightNodeExplorerPage />} />
                 <Route
                   exact
-                  path="/dapp/transactions/:transactionTimeHash"
+                  path="/dapp/transactions/:transactionHash"
                   render={() => <Pages.LightNodeExplorerTransactionPage />}
                 />
                 <Route
@@ -84,7 +84,7 @@ class App extends React.Component {
                 <Route exact path="/explorer" render={() => <Pages.FullNodeExplorerPage />} />
                 <Route
                   exact
-                  path="/server/transactions/:transactionTimeHash"
+                  path="/server/transactions/:transactionHash"
                   render={() => <Pages.FullNodeExplorerTransactionPage />}
                 />
                 <Route

--- a/packages/element-app/src/redux/fullNode/handlers.js
+++ b/packages/element-app/src/redux/fullNode/handlers.js
@@ -180,7 +180,6 @@ export default withHandlers({
     }
     set({ resolving: false });
   },
-  // FIXME
   getSidetreeOperationsFromTransactionHash: ({ set }) => async (transactionHash) => {
     set({ loading: true });
     const { data } = await axios.get(

--- a/packages/element-app/src/redux/fullNode/handlers.js
+++ b/packages/element-app/src/redux/fullNode/handlers.js
@@ -180,11 +180,11 @@ export default withHandlers({
     }
     set({ resolving: false });
   },
-
-  getSidetreeOperationsFromTransactionTimeHash: ({ set }) => async (transactionTimeHash) => {
+  // FIXME
+  getSidetreeOperationsFromTransactionTimeHash: ({ set }) => async (transactionHash) => {
     set({ loading: true });
     const { data } = await axios.get(
-      `${API_BASE}/sidetree/transaction/${transactionTimeHash}/summary`,
+      `${API_BASE}/sidetree/transaction/${transactionHash}/summary`,
     );
     set({ sidetreeTransactionSummary: data, loading: false });
   },

--- a/packages/element-app/src/redux/fullNode/handlers.js
+++ b/packages/element-app/src/redux/fullNode/handlers.js
@@ -124,14 +124,9 @@ export default withHandlers({
     set({ resolving: false });
   },
 
-  getSidetreeTransactions: ({ set }) => async (args) => {
+  getSidetreeTransactions: ({ set }) => async () => {
     set({ loading: true });
-
-    let endpoint = `${API_BASE}/sidetree/transactions`;
-    if (args) {
-      endpoint += `?since=${args.since}&transactionTimeHash=${args.transactionTimeHash}}`;
-    }
-    const { data } = await axios.get(endpoint);
+    const { data } = await axios.get(`${API_BASE}/sidetree/transactions`);
     set({ sidetreeTxns: data.reverse(), loading: false });
   },
 

--- a/packages/element-app/src/redux/fullNode/handlers.js
+++ b/packages/element-app/src/redux/fullNode/handlers.js
@@ -124,9 +124,9 @@ export default withHandlers({
     set({ resolving: false });
   },
 
-  getSidetreeTransactions: ({ set }) => async () => {
+  getSidetreeTransactions: ({ set }) => async ({ limit }) => {
     set({ loading: true });
-    const { data } = await axios.get(`${API_BASE}/sidetree/transactions`);
+    const { data } = await axios.get(`${API_BASE}/sidetree/transactions?limit=${limit}`);
     set({ sidetreeTxns: data.reverse(), loading: false });
   },
 

--- a/packages/element-app/src/redux/fullNode/handlers.js
+++ b/packages/element-app/src/redux/fullNode/handlers.js
@@ -183,7 +183,6 @@ export default withHandlers({
 
   getSidetreeOperationsFromTransactionTimeHash: ({ set }) => async (transactionTimeHash) => {
     set({ loading: true });
-    // const summary = await sidetree.getTransactionSummary(transactionTimeHash);
     const { data } = await axios.get(
       `${API_BASE}/sidetree/transaction/${transactionTimeHash}/summary`,
     );

--- a/packages/element-app/src/redux/fullNode/handlers.js
+++ b/packages/element-app/src/redux/fullNode/handlers.js
@@ -181,7 +181,7 @@ export default withHandlers({
     set({ resolving: false });
   },
   // FIXME
-  getSidetreeOperationsFromTransactionTimeHash: ({ set }) => async (transactionHash) => {
+  getSidetreeOperationsFromTransactionHash: ({ set }) => async (transactionHash) => {
     set({ loading: true });
     const { data } = await axios.get(
       `${API_BASE}/sidetree/transaction/${transactionHash}/summary`,

--- a/packages/element-app/src/redux/lightNode/handlers.js
+++ b/packages/element-app/src/redux/lightNode/handlers.js
@@ -70,12 +70,12 @@ export default withHandlers({
     }
     set({ sidetreeTxns: records.reverse(), loading: false });
   },
-  getSidetreeOperationsFromTransactionTimeHash: ({
+  getSidetreeOperationsFromTransactionHash: ({
     sidetree,
     set,
-  }) => async (transactionTimeHash) => {
+  }) => async (transactionHash) => {
     set({ loading: true });
-    const summary = await sidetree.getTransactionSummary(transactionTimeHash);
+    const summary = await sidetree.getTransactionSummary(transactionHash);
     set({ sidetreeTransactionSummary: summary, loading: false });
   },
   getOperationsForDidUniqueSuffix: ({ sidetree, set }) => async (didUniqueSuffix) => {

--- a/packages/element-lib/src/adapters/blockchain/ethereum/index.js
+++ b/packages/element-lib/src/adapters/blockchain/ethereum/index.js
@@ -26,7 +26,6 @@ const getWeb3 = ({ mnemonic, hdPath, providerUrl }) => {
 
 const eventLogToSidetreeTransaction = log => ({
   transactionTime: log.blockNumber,
-  // FIXME
   transactionTimeHash: log.blockHash,
   transactionHash: log.transactionHash,
   transactionNumber: log.args.transactionNumber.toNumber(),

--- a/packages/element-lib/src/adapters/blockchain/ethereum/index.js
+++ b/packages/element-lib/src/adapters/blockchain/ethereum/index.js
@@ -146,7 +146,7 @@ class EthereumBlockchain {
     return this.extendSidetreeTransactionWithTimestamp(txns);
   }
 
-  async getTransaction(transactionHash) {
+  async getEthereumTransaction(transactionHash) {
     const transaction = await new Promise((resolve, reject) => {
       this.web3.eth.getTransaction(transactionHash, (err, data) => {
         if (err) {

--- a/packages/element-lib/src/adapters/blockchain/ethereum/index.js
+++ b/packages/element-lib/src/adapters/blockchain/ethereum/index.js
@@ -123,8 +123,15 @@ class EthereumBlockchain {
     return instance;
   }
 
+  async getInstance() {
+    if (!this.instance) {
+      this.instance = await this.anchorContract.at(this.anchorContractAddress);
+    }
+    return this.instance;
+  }
+
   async getTransactions(fromBlock, toBlock, options) {
-    const instance = await this.anchorContract.at(this.anchorContractAddress);
+    const instance = await this.getInstance();
     const logs = await instance.getPastEvents('Anchor', {
       // TODO: add indexing here...
       // https://ethereum.stackexchange.com/questions/8658/what-does-the-indexed-keyword-do
@@ -162,7 +169,7 @@ class EthereumBlockchain {
   async write(anchorFileHash) {
     await this.resolving;
     const [from] = await getAccounts(this.web3);
-    const instance = await this.anchorContract.at(this.anchorContractAddress);
+    const instance = await this.getInstance();
     const bytes32EncodedHash = base58EncodedMultihashToBytes32(anchorFileHash);
     try {
       const receipt = await this.retryWithLatestTransactionCount(

--- a/packages/element-lib/src/adapters/blockchain/ethereum/index.js
+++ b/packages/element-lib/src/adapters/blockchain/ethereum/index.js
@@ -26,7 +26,7 @@ const getWeb3 = ({ mnemonic, hdPath, providerUrl }) => {
 
 const eventLogToSidetreeTransaction = log => ({
   transactionTime: log.blockNumber,
-  // FIMXME
+  // FIXME
   transactionTimeHash: log.blockHash,
   transactionHash: log.transactionHash,
   transactionNumber: log.args.transactionNumber.toNumber(),

--- a/packages/element-lib/src/adapters/blockchain/ethereum/index.js
+++ b/packages/element-lib/src/adapters/blockchain/ethereum/index.js
@@ -26,7 +26,9 @@ const getWeb3 = ({ mnemonic, hdPath, providerUrl }) => {
 
 const eventLogToSidetreeTransaction = log => ({
   transactionTime: log.blockNumber,
+  // FIMXME
   transactionTimeHash: log.blockHash,
+  transactionHash: log.transactionHash,
   transactionNumber: log.args.transactionNumber.toNumber(),
   anchorFileHash: bytes32EnodedMultihashToBase58EncodedMultihash(log.args.anchorFileHash),
 });
@@ -143,6 +145,18 @@ class EthereumBlockchain {
       return txns;
     }
     return this.extendSidetreeTransactionWithTimestamp(txns);
+  }
+
+  async getTransaction(transactionHash) {
+    const transaction = await new Promise((resolve, reject) => {
+      this.web3.eth.getTransaction(transactionHash, (err, data) => {
+        if (err) {
+          return reject(err);
+        }
+        return resolve(data);
+      });
+    });
+    return transaction;
   }
 
   async getBlockchainTime(blockHashOrBlockNumber) {

--- a/packages/element-lib/src/adapters/database/ElementRXDBAdapter.js
+++ b/packages/element-lib/src/adapters/database/ElementRXDBAdapter.js
@@ -58,6 +58,7 @@ class ElementRXDBAdapter {
           },
           transactionTime: {},
           transactionTimeHash: {},
+          transactionHash: {},
           transactionNumber: {},
           transactionTimestamp: {},
           consideredUnresolvableUntil: {},

--- a/packages/element-lib/src/sidetree-v2/func.js
+++ b/packages/element-lib/src/sidetree-v2/func.js
@@ -62,19 +62,23 @@ const batchFileToOperations = batchFile => batchFile.operations.map((op) => {
 });
 
 const readThenWriteToCache = async (sidetree, hash) => {
+  console.log({ hash });
   const cachedRecord = await sidetree.db.read(hash);
+  console.log({ cachedRecord });
   let record;
   if (!cachedRecord) {
+    console.info('storage read');
     record = await sidetree.storage.read(hash);
     await sidetree.db.write(hash, record);
   } else {
+    console.info('cache read');
     record = cachedRecord;
   }
   return record;
 };
 
 const syncTransaction = async (sidetree, transaction, onlyDidUniqueSuffix = null) => {
-  console.log('sync', transaction.transactionNumber);
+  console.info('sync', transaction.transactionNumber);
   try {
     isTransactionValid(transaction);
     const anchorFile = await readThenWriteToCache(sidetree, transaction.anchorFileHash);

--- a/packages/element-lib/src/sidetree-v2/func.js
+++ b/packages/element-lib/src/sidetree-v2/func.js
@@ -65,11 +65,9 @@ const readThenWriteToCache = async (sidetree, hash) => {
   const cachedRecord = await sidetree.db.read(hash);
   let record;
   if (!cachedRecord) {
-    console.info('storage read', hash);
     record = await sidetree.storage.read(hash);
     await sidetree.db.write(hash, record);
   } else {
-    console.info('cache read', hash);
     record = cachedRecord;
   }
   return record;

--- a/packages/element-lib/src/sidetree-v2/func.js
+++ b/packages/element-lib/src/sidetree-v2/func.js
@@ -62,16 +62,14 @@ const batchFileToOperations = batchFile => batchFile.operations.map((op) => {
 });
 
 const readThenWriteToCache = async (sidetree, hash) => {
-  console.log({ hash });
   const cachedRecord = await sidetree.db.read(hash);
-  console.log({ cachedRecord });
   let record;
   if (!cachedRecord) {
-    console.info('storage read');
+    console.info('storage read', hash);
     record = await sidetree.storage.read(hash);
     await sidetree.db.write(hash, record);
   } else {
-    console.info('cache read');
+    console.info('cache read', hash);
     record = cachedRecord;
   }
   return record;

--- a/packages/element-lib/src/sidetree-v2/func.js
+++ b/packages/element-lib/src/sidetree-v2/func.js
@@ -61,23 +61,23 @@ const batchFileToOperations = batchFile => batchFile.operations.map((op) => {
   };
 });
 
-const getAnchorFile = async (sidetree, anchorFileHash) => {
-  const cachedAnchorFile = await sidetree.db.read(anchorFileHash);
-  let anchorFile;
-  if (!cachedAnchorFile) {
-    anchorFile = await sidetree.storage.read(anchorFileHash);
-    await sidetree.db.write(anchorFileHash, anchorFile);
+const readThenWriteToCache = async (sidetree, hash) => {
+  const cachedRecord = await sidetree.db.read(hash);
+  let record;
+  if (!cachedRecord) {
+    record = await sidetree.storage.read(hash);
+    await sidetree.db.write(hash, record);
   } else {
-    anchorFile = cachedAnchorFile;
+    record = cachedRecord;
   }
-  return anchorFile;
+  return record;
 };
 
 const syncTransaction = async (sidetree, transaction, onlyDidUniqueSuffix = null) => {
   console.log('sync', transaction.transactionNumber);
   try {
     isTransactionValid(transaction);
-    const anchorFile = await getAnchorFile(sidetree, transaction.anchorFileHash);
+    const anchorFile = await readThenWriteToCache(sidetree, transaction.anchorFileHash);
     isAnchorFileValid(anchorFile);
     // Only sync the batch files containing operations about that didUniqueSuffix if provided
     if (onlyDidUniqueSuffix && !anchorFile.didUniqueSuffixes.includes(onlyDidUniqueSuffix)) {
@@ -168,4 +168,5 @@ module.exports = {
   syncTransaction,
   signEncodedPayload,
   verifyOperationSignature,
+  readThenWriteToCache,
 };

--- a/packages/element-lib/src/sidetree-v2/index.js
+++ b/packages/element-lib/src/sidetree-v2/index.js
@@ -2,8 +2,8 @@ const {
   resolve,
   sync,
   batchWrite,
-  getTransactions,
 } = require('./protocol');
+const { getTransactions, getTransactionSummary } = require('./protocol/getTransactions');
 const BatchScheduler = require('./protocol/BatchScheduler');
 const op = require('./op');
 const func = require('./func');
@@ -35,6 +35,7 @@ class Sidetree {
     this.parameters = parameters;
 
     this.getTransactions = getTransactions(this);
+    this.getTransactionSummary = getTransactionSummary(this);
   }
 }
 

--- a/packages/element-lib/src/sidetree-v2/index.js
+++ b/packages/element-lib/src/sidetree-v2/index.js
@@ -1,4 +1,9 @@
-const { resolve, sync, batchWrite } = require('./protocol');
+const {
+  resolve,
+  sync,
+  batchWrite,
+  getTransactions,
+} = require('./protocol');
 const BatchScheduler = require('./protocol/BatchScheduler');
 const op = require('./op');
 const func = require('./func');
@@ -28,6 +33,8 @@ class Sidetree {
     this.batchScheduler = new BatchScheduler(this);
     // Parameters
     this.parameters = parameters;
+
+    this.getTransactions = getTransactions(this);
   }
 }
 

--- a/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
+++ b/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
@@ -4,9 +4,11 @@ const getTransactions = sidetree => async () => {
     'latest',
     { omitTimestamp: true },
   );
-  // Only get the last 20 transactions
-  const limit = 20;
-  return transactions.slice(-limit);
+  // Only get the last 20 transactions to avoid crashing the page
+  const lastTransactions = transactions.slice(-20);
+  const lastTransactionsWithTimestamp = await sidetree.blockchain
+    .extendSidetreeTransactionWithTimestamp(lastTransactions);
+  return lastTransactionsWithTimestamp;
 };
 
 module.exports = getTransactions;

--- a/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
+++ b/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
@@ -13,7 +13,7 @@ const getTransactions = sidetree => async () => {
 };
 
 const getTransactionSummary = sidetree => async (transactionHash) => {
-  const { blockNumber } = await sidetree.blockchain.getTransaction(transactionHash);
+  const { blockNumber } = await sidetree.blockchain.getEthereumTransaction(transactionHash);
   const transactions = await sidetree.blockchain.getTransactions(blockNumber, blockNumber);
   const transaction = transactions.find(t => t.transactionHash === transactionHash);
   const anchorFile = await sidetree.func.readThenWriteToCache(sidetree, transaction.anchorFileHash);

--- a/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
+++ b/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
@@ -1,13 +1,14 @@
-const getTransactions = sidetree => async () => {
-  const transactions = await sidetree.blockchain.getTransactions(
+const getTransactions = sidetree => async ({ limit } = {}) => {
+  let transactions = await sidetree.blockchain.getTransactions(
     0,
     'latest',
     { omitTimestamp: true },
   );
-  // Only get the last 20 transactions to avoid crashing the page
-  const lastTransactions = transactions.slice(-20);
+  if (limit) {
+    transactions = transactions.slice(-limit);
+  }
   const lastTransactionsWithTimestamp = await sidetree.blockchain
-    .extendSidetreeTransactionWithTimestamp(lastTransactions);
+    .extendSidetreeTransactionWithTimestamp(transactions);
   return lastTransactionsWithTimestamp;
 };
 

--- a/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
+++ b/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
@@ -1,14 +1,7 @@
-const getTransactions = sidetree => async ({ transactionTimeHash } = {}) => {
-  let since = 0;
-  let end = 'latest';
-  if (transactionTimeHash) {
-    const blockchainTime = await sidetree.blockchain.getBlockchainTime(transactionTimeHash);
-    since = blockchainTime.time;
-    end = since + 1;
-  }
+const getTransactions = sidetree => async () => {
   const transactions = await sidetree.blockchain.getTransactions(
-    since,
-    end,
+    0,
+    'latest',
     { omitTimestamp: true },
   );
   // Only get the last 20 transactions to avoid crashing the page
@@ -18,9 +11,10 @@ const getTransactions = sidetree => async ({ transactionTimeHash } = {}) => {
   return lastTransactionsWithTimestamp;
 };
 
-const getTransactionSummary = sidetree => async (transactionTimeHash) => {
-  const transactions = await sidetree.getTransactions({ transactionTimeHash });
-  const transaction = transactions.pop();
+const getTransactionSummary = sidetree => async (transactionHash) => {
+  const { blockNumber } = await sidetree.blockchain.getTransaction(transactionHash);
+  const transactions = await sidetree.blockchain.getTransactions(blockNumber, blockNumber);
+  const transaction = transactions.find(t => t.transactionHash === transactionHash);
   const anchorFile = await sidetree.func.readThenWriteToCache(sidetree, transaction.anchorFileHash);
   const batchFile = await sidetree.func.readThenWriteToCache(sidetree, anchorFile.batchFileHash);
   let operations;

--- a/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
+++ b/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
@@ -4,7 +4,9 @@ const getTransactions = sidetree => async () => {
     'latest',
     { omitTimestamp: true },
   );
-  return transactions;
+  // Only get the last 20 transactions
+  const limit = 20;
+  return transactions.slice(-limit);
 };
 
 module.exports = getTransactions;

--- a/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
+++ b/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
@@ -19,7 +19,8 @@ const getTransactions = sidetree => async ({ transactionTimeHash } = {}) => {
 };
 
 const getTransactionSummary = sidetree => async (transactionTimeHash) => {
-  const transaction = await sidetree.getTransactions({ transactionTimeHash });
+  const transactions = await sidetree.getTransactions({ transactionTimeHash });
+  const transaction = transactions.pop();
   const anchorFile = await sidetree.func.readThenWriteToCache(sidetree, transaction.anchorFileHash);
   const batchFile = await sidetree.func.readThenWriteToCache(sidetree, anchorFile.batchFileHash);
   let operations;

--- a/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
+++ b/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
@@ -1,0 +1,10 @@
+const getTransactions = sidetree => async () => {
+  const transactions = await sidetree.blockchain.getTransactions(
+    0,
+    'latest',
+    { omitTimestamp: true },
+  );
+  return transactions;
+};
+
+module.exports = getTransactions;

--- a/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
+++ b/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
@@ -1,3 +1,4 @@
+// TODO refactor
 const getTransactions = sidetree => async () => {
   const transactions = await sidetree.blockchain.getTransactions(
     0,

--- a/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
+++ b/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
@@ -11,4 +11,25 @@ const getTransactions = sidetree => async () => {
   return lastTransactionsWithTimestamp;
 };
 
-module.exports = getTransactions;
+const getTransactionSummary = sidetree => async (transactionTimeHash) => {
+  const transaction = await sidetree.getTransactions({ transactionTimeHash });
+  const anchorFile = await sidetree.func.readThenWriteToCache(sidetree, transaction.anchorFileHash);
+  const batchFile = await sidetree.func.readThenWriteToCache(sidetree, anchorFile.batchFileHash);
+  let operations;
+  try {
+    operations = sidetree.func.batchFileToOperations(batchFile);
+  } catch (e) {
+    operations = [];
+  }
+  return {
+    transaction,
+    anchorFile,
+    batchFile,
+    operations,
+  };
+};
+
+module.exports = {
+  getTransactions,
+  getTransactionSummary,
+};

--- a/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
+++ b/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
@@ -1,4 +1,3 @@
-// TODO refactor
 const getTransactions = sidetree => async () => {
   const transactions = await sidetree.blockchain.getTransactions(
     0,

--- a/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
+++ b/packages/element-lib/src/sidetree-v2/protocol/getTransactions.js
@@ -1,7 +1,14 @@
-const getTransactions = sidetree => async () => {
+const getTransactions = sidetree => async ({ transactionTimeHash } = {}) => {
+  let since = 0;
+  let end = 'latest';
+  if (transactionTimeHash) {
+    const blockchainTime = await sidetree.blockchain.getBlockchainTime(transactionTimeHash);
+    since = blockchainTime.time;
+    end = since + 1;
+  }
   const transactions = await sidetree.blockchain.getTransactions(
-    0,
-    'latest',
+    since,
+    end,
     { omitTimestamp: true },
   );
   // Only get the last 20 transactions to avoid crashing the page

--- a/packages/element-lib/src/sidetree-v2/protocol/index.js
+++ b/packages/element-lib/src/sidetree-v2/protocol/index.js
@@ -1,9 +1,11 @@
 const resolve = require('./resolve');
 const sync = require('./sync');
 const batchWrite = require('./batchWrite');
+const getTransactions = require('./getTransactions');
 
 module.exports = {
   resolve,
   sync,
   batchWrite,
+  getTransactions,
 };

--- a/packages/element-lib/src/sidetree-v2/protocol/index.js
+++ b/packages/element-lib/src/sidetree-v2/protocol/index.js
@@ -1,11 +1,9 @@
 const resolve = require('./resolve');
 const sync = require('./sync');
 const batchWrite = require('./batchWrite');
-const getTransactions = require('./getTransactions');
 
 module.exports = {
   resolve,
   sync,
   batchWrite,
-  getTransactions,
 };


### PR DESCRIPTION
https://transmute.atlassian.net/browse/MUTE-482

## API
- Add "transactions" and "transaction summary" endpoints
- Remove unused "operations" endpoint

## APP
- Use `transactionHash` instead of `transactionTimeHash` to represent a transaction
- Remove unused logic for filtering the Block explorer
- Add link to ethereum transaction in the SidetreeTransaction component

## LIB
- Add `transactionHash` field to the Transaction object
- Add a `getEthereumTransaction` method to get an Ethereum Transaction by transactionHash
- Add `getInstance` method to avoid recreating the instance every time (2s performance improvement)
- Add a `readThenWriteToCache` method for more caching
- Add methods for getting transactions
