### PR TITLE
Order transactions after reading them from cache

### DIFF
--- a/packages/element-api/src/express/routes/sidetree/index.js
+++ b/packages/element-api/src/express/routes/sidetree/index.js
@@ -159,11 +159,8 @@ router.get('/operations/:didUniqueSuffix', async (req, res, next) => {
     const didUniqueSuffix = req.params.didUniqueSuffix.split(':').pop();
     const sidetree = req.app.get('sidetree');
     const operations = await sidetree.db.readCollection(didUniqueSuffix);
-    operations.sort(
-      (op1, op2) =>
-        op1.transaction.transactionNumber - op2.transaction.transactionNumber
-    );
-    res.status(200).json(operations);
+    const orderedOperations = sidetree.func.getOrderedOperations(operations);
+    res.status(200).json(orderedOperations);
   } catch (e) {
     next(e);
   }

--- a/packages/element-api/src/express/routes/sidetree/index.js
+++ b/packages/element-api/src/express/routes/sidetree/index.js
@@ -159,6 +159,10 @@ router.get('/operations/:didUniqueSuffix', async (req, res, next) => {
     const didUniqueSuffix = req.params.didUniqueSuffix.split(':').pop();
     const sidetree = req.app.get('sidetree');
     const operations = await sidetree.db.readCollection(didUniqueSuffix);
+    operations.sort(
+      (op1, op2) =>
+        op1.transaction.transactionNumber - op2.transaction.transactionNumber
+    );
     res.status(200).json(operations);
   } catch (e) {
     next(e);

--- a/packages/element-app/src/components/Pages/DIDProfilePage/DIDProfilePage.js
+++ b/packages/element-app/src/components/Pages/DIDProfilePage/DIDProfilePage.js
@@ -104,7 +104,7 @@ export class DIDProfilePage extends Component {
                 <Typography variant="h5">My Operations</Typography>
               </Grid>
               {sidetreeOperations.map(op => (
-                <Grid item xs={12} key={op.operation.operationHash}>
+                <Grid item xs={12} key={op.transaction.transactionNumber}>
                   <SidetreeOperation operation={op} expanded={false} />
                 </Grid>
               ))}

--- a/packages/element-app/src/components/Pages/ExplorerOperationsPage/ExplorerOperationsPage.js
+++ b/packages/element-app/src/components/Pages/ExplorerOperationsPage/ExplorerOperationsPage.js
@@ -44,7 +44,7 @@ export class ExplorerOperationsPage extends Component {
             </Grid>
           )}
           {sidetreeOperations.map(op => (
-            <Grid item xs={12} key={op.operation.operationHash}>
+            <Grid item xs={12} key={op.transaction.transactionNumber}>
               <SidetreeOperation operation={op} expanded={false} />
               <br />
             </Grid>

--- a/packages/element-app/src/redux/lightNode/handlers.js
+++ b/packages/element-app/src/redux/lightNode/handlers.js
@@ -9,11 +9,8 @@ export default withHandlers({
     const myDidDocument = await sidetree.resolve(didUniqueSuffix, true);
     set({ myDidDocument });
     const operations = await sidetree.db.readCollection(didUniqueSuffix);
-    operations.sort(
-      (op1, op2) =>
-        op1.transaction.transactionNumber - op2.transaction.transactionNumber
-    );
-    set({ sidetreeOperations: operations });
+    const orderedOperations = sidetree.func.getOrderedOperations(operations);
+    set({ sidetreeOperations: orderedOperations });
   },
   getOperationsForDidUniqueSuffix: ({
     sidetree,
@@ -23,11 +20,8 @@ export default withHandlers({
     const myDidDocument = await sidetree.resolve(didUniqueSuffix, true);
     set({ didDocumentForOperations: myDidDocument });
     const operations = await sidetree.db.readCollection(didUniqueSuffix);
-    operations.sort(
-      (op1, op2) =>
-        op1.transaction.transactionNumber - op2.transaction.transactionNumber
-    );
-    set({ sidetreeOperations: operations, loading: false });
+    const orderedOperations = sidetree.func.getOrderedOperations(operations);
+    set({ sidetreeOperations: orderedOperations, loading: false });
   },
   createDID: ({
     snackbarMessage,
@@ -77,11 +71,8 @@ export default withHandlers({
     const newPublicKey = getDidDocumentKey(newKey);
     const didUniqueSuffix = await getMyDidUniqueSuffix();
     const operations = await sidetree.db.readCollection(didUniqueSuffix);
-    operations.sort(
-      (op1, op2) =>
-        op1.transaction.transactionNumber - op2.transaction.transactionNumber
-    );
-    const lastOperation = operations.pop();
+    const orderedOperations = sidetree.func.getOrderedOperations(operations);
+    const lastOperation = orderedOperations.pop();
     const { operationHash } = lastOperation.operation;
     const updatePayload = await createAddKeyRequest(
       newPublicKey,
@@ -117,11 +108,8 @@ export default withHandlers({
     set({ resolving: true });
     const didUniqueSuffix = await getMyDidUniqueSuffix();
     const operations = await sidetree.db.readCollection(didUniqueSuffix);
-    operations.sort(
-      (op1, op2) =>
-        op1.transaction.transactionNumber - op2.transaction.transactionNumber
-    );
-    const lastOperation = operations.pop();
+    const orderedOperations = sidetree.func.getOrderedOperations(operations);
+    const lastOperation = orderedOperations.pop();
     const { operationHash } = lastOperation.operation;
     const updatePayload = await createRemoveKeyRequest(
       kid,

--- a/packages/element-app/src/redux/lightNode/handlers.js
+++ b/packages/element-app/src/redux/lightNode/handlers.js
@@ -9,6 +9,10 @@ export default withHandlers({
     const myDidDocument = await sidetree.resolve(didUniqueSuffix, true);
     set({ myDidDocument });
     const operations = await sidetree.db.readCollection(didUniqueSuffix);
+    operations.sort(
+      (op1, op2) =>
+        op1.transaction.transactionNumber - op2.transaction.transactionNumber
+    );
     set({ sidetreeOperations: operations });
   },
   getOperationsForDidUniqueSuffix: ({
@@ -19,6 +23,10 @@ export default withHandlers({
     const myDidDocument = await sidetree.resolve(didUniqueSuffix, true);
     set({ didDocumentForOperations: myDidDocument });
     const operations = await sidetree.db.readCollection(didUniqueSuffix);
+    operations.sort(
+      (op1, op2) =>
+        op1.transaction.transactionNumber - op2.transaction.transactionNumber
+    );
     set({ sidetreeOperations: operations, loading: false });
   },
   createDID: ({
@@ -69,6 +77,10 @@ export default withHandlers({
     const newPublicKey = getDidDocumentKey(newKey);
     const didUniqueSuffix = await getMyDidUniqueSuffix();
     const operations = await sidetree.db.readCollection(didUniqueSuffix);
+    operations.sort(
+      (op1, op2) =>
+        op1.transaction.transactionNumber - op2.transaction.transactionNumber
+    );
     const lastOperation = operations.pop();
     const { operationHash } = lastOperation.operation;
     const updatePayload = await createAddKeyRequest(
@@ -105,6 +117,10 @@ export default withHandlers({
     set({ resolving: true });
     const didUniqueSuffix = await getMyDidUniqueSuffix();
     const operations = await sidetree.db.readCollection(didUniqueSuffix);
+    operations.sort(
+      (op1, op2) =>
+        op1.transaction.transactionNumber - op2.transaction.transactionNumber
+    );
     const lastOperation = operations.pop();
     const { operationHash } = lastOperation.operation;
     const updatePayload = await createRemoveKeyRequest(

--- a/packages/element-lib/src/__tests__/__fixtures__/unorderedOperations.json
+++ b/packages/element-lib/src/__tests__/__fixtures__/unorderedOperations.json
@@ -1,0 +1,149 @@
+[
+  {
+    "operation": {
+      "decodedHeader": {
+        "kid": "#primary",
+        "operation": "update",
+        "alg": "ES256K"
+      },
+      "operationHash": "EiB9uXtqPgPVTVFto_zslX_CpOE7xzV7xhuP_oF_0Usxdw",
+      "decodedOperation": {
+        "protected": "eyJvcGVyYXRpb24iOiJ1cGRhdGUiLCJraWQiOiIjcHJpbWFyeSIsImFsZyI6IkVTMjU2SyJ9",
+        "signature": "DZTdKxXRDyC8bQc-I4eZIs8lg_1zWef5Ou20CUHA46E4cIjG4FoZJAoDZMpzjTVltDR-D8DW_HvmnKUewIJD9g",
+        "payload": "eyJkaWRVbmlxdWVTdWZmaXgiOiJFaUMxVGdvc3VpNU82aWtURlFXcklNZURhMlNRZHhKWmpHU1pDak51LUFBclZBIiwicHJldmlvdXNPcGVyYXRpb25IYXNoIjoiRWlELU5hdnVKRFpuMDlnWlNPRk1qNWhrVk5fcE0xYlJDLUVWVGZydmpKRk8xZyIsInBhdGNoZXMiOlt7ImFjdGlvbiI6ImFkZC1wdWJsaWMta2V5cyIsInB1YmxpY0tleXMiOlt7ImlkIjoiI2VkdiIsInVzYWdlIjoic2lnbmluZyIsInR5cGUiOiJFZDI1NTE5VmVyaWZpY2F0aW9uS2V5MjAxOCIsInB1YmxpY0tleUJhc2U1OCI6ImF0RUJ1SHlwU2tReDc0ODZ4VDVGVWtvQkxxdk5jV3lOSzJYejlFUGpkTXkifV19XX0"
+      },
+      "decodedOperationPayload": {
+        "patches": [
+          {
+            "action": "add-public-keys",
+            "publicKeys": [
+              {
+                "type": "Ed25519VerificationKey2018",
+                "publicKeyBase58": "atEBuHypSkQx7486xT5FUkoBLqvNcWyNK2Xz9EPjdMy",
+                "id": "#edv",
+                "usage": "signing"
+              }
+            ]
+          }
+        ],
+        "previousOperationHash": "EiD-NavuJDZn09gZSOFMj5hkVN_pM1bRC-EVTfrvjJFO1g",
+        "didUniqueSuffix": "EiC1Tgosui5O6ikTFQWrIMeDa2SQdxJZjGSZCjNu-AArVA"
+      }
+    },
+    "didUniqueSuffix": "EiC1Tgosui5O6ikTFQWrIMeDa2SQdxJZjGSZCjNu-AArVA",
+    "type": "EiC1Tgosui5O6ikTFQWrIMeDa2SQdxJZjGSZCjNu-AArVA",
+    "transaction": {
+      "transactionNumber": 814,
+      "anchorFileHash": "QmZ5ufPfRRbAAFe1HTww6Ad3RMqj7wwYWNJNN3WDH7oqWx",
+      "transactionTimeHash": "0x5656dcc58267d438b9d19d2f3ce0d83e98b4350a7853ecd56af17d9f7452a91b",
+      "transactionTime": 7177660,
+      "transactionHash": "0x140c67b1f00ec84d3f569972d67ad6b0f23dddf23976dc0205cb23b71f96d285",
+      "transactionTimestamp": 1579761608
+    }
+  },
+  {
+    "operation": {
+      "decodedHeader": {
+        "operation": "create",
+        "alg": "ES256K",
+        "kid": "#primary"
+      },
+      "operationHash": "EiC1Tgosui5O6ikTFQWrIMeDa2SQdxJZjGSZCjNu-AArVA",
+      "decodedOperation": {
+        "signature": "xvuj1RYdpD333U9r3Egae5OltPDNuP6XgdttX7EumksBp_MSWXXbLTApokOL60HLePdnAyENHMnqkB9sgDLt6A",
+        "payload": "eyJAY29udGV4dCI6Imh0dHBzOi8vdzNpZC5vcmcvZGlkL3YxIiwicHVibGljS2V5IjpbeyJ0eXBlIjoiU2VjcDI1NmsxVmVyaWZpY2F0aW9uS2V5MjAxOCIsImlkIjoiI3ByaW1hcnkiLCJ1c2FnZSI6InNpZ25pbmciLCJwdWJsaWNLZXlIZXgiOiIwMzYxZjI4NmFkYTJhNmIyYzc0YmM2ZWQ0NGE3MWVmNTlmYjlkZDE1ZWNhOTI4M2NiZTU2MDhhZWI1MTY3MzBmMzMifSx7InR5cGUiOiJTZWNwMjU2azFWZXJpZmljYXRpb25LZXkyMDE4IiwiaWQiOiIjcmVjb3ZlcnkiLCJ1c2FnZSI6InJlY292ZXJ5IiwicHVibGljS2V5SGV4IjoiMDJjMDA5ODI2ODEwODEzNzJjYmI5NDFjZDJjOTc0NTkwODMxNmUxMzczYWMzMzM0NzlmMGRlYWJjYWQwZTlkNTc0In0seyJ0eXBlIjoiRWQyNTUxOVZlcmlmaWNhdGlvbktleTIwMTgiLCJpZCI6IiNlZHYiLCJ1c2FnZSI6InNpZ25pbmciLCJwdWJsaWNLZXlCYXNlNTgiOiJhdEVCdUh5cFNrUXg3NDg2eFQ1RlVrb0JMcXZOY1d5TksyWHo5RVBqZE15In1dLCJhdXRoZW50aWNhdGlvbiI6WyIjZWR2Il0sImFzc2VydGlvbk1ldGhvZCI6WyIjZWR2Il0sImNhcGFiaWxpdHlEZWxlZ2F0aW9uIjpbIiNlZHYiXSwiY2FwYWJpbGl0eUludm9jYXRpb24iOlsiI2VkdiJdLCJrZXlBZ3JlZW1lbnQiOlt7ImlkIjoiI2tleUFncmVlbWVudCIsInR5cGUiOiJYMjU1MTlLZXlBZ3JlZW1lbnRLZXkyMDE5IiwidXNhZ2UiOiJzaWduaW5nIiwicHVibGljS2V5QmFzZTU4IjoiRU5wZms5SzlKNnVzczVxdTZCckFzemlvRTczMm1ZQ29ibU1QU3B2QjNmYU0ifV19",
+        "protected": "eyJvcGVyYXRpb24iOiJjcmVhdGUiLCJraWQiOiIjcHJpbWFyeSIsImFsZyI6IkVTMjU2SyJ9"
+      },
+      "decodedOperationPayload": {
+        "authentication": [
+          "#edv"
+        ],
+        "capabilityDelegation": [
+          "#edv"
+        ],
+        "keyAgreement": [
+          {
+            "id": "#keyAgreement",
+            "usage": "signing",
+            "type": "X25519KeyAgreementKey2019",
+            "publicKeyBase58": "ENpfk9K9J6uss5qu6BrAszioE732mYCobmMPSpvB3faM"
+          }
+        ],
+        "assertionMethod": [
+          "#edv"
+        ],
+        "@context": "https://w3id.org/did/v1",
+        "publicKey": [
+          {
+            "id": "#primary",
+            "usage": "signing",
+            "publicKeyHex": "0361f286ada2a6b2c74bc6ed44a71ef59fb9dd15eca9283cbe5608aeb516730f33",
+            "type": "Secp256k1VerificationKey2018"
+          },
+          {
+            "publicKeyHex": "02c00982681081372cbb941cd2c9745908316e1373ac333479f0deabcad0e9d574",
+            "type": "Secp256k1VerificationKey2018",
+            "id": "#recovery",
+            "usage": "recovery"
+          },
+          {
+            "type": "Ed25519VerificationKey2018",
+            "publicKeyBase58": "atEBuHypSkQx7486xT5FUkoBLqvNcWyNK2Xz9EPjdMy",
+            "id": "#edv",
+            "usage": "signing"
+          }
+        ],
+        "capabilityInvocation": [
+          "#edv"
+        ]
+      }
+    },
+    "didUniqueSuffix": "EiC1Tgosui5O6ikTFQWrIMeDa2SQdxJZjGSZCjNu-AArVA",
+    "type": "EiC1Tgosui5O6ikTFQWrIMeDa2SQdxJZjGSZCjNu-AArVA",
+    "transaction": {
+      "transactionTimestamp": 1579761380,
+      "transactionNumber": 812,
+      "anchorFileHash": "QmfHpVe9cHZpr1W5AVzcjMVp5WCHUBpTL7NTFHC2kW2oJN",
+      "transactionTimeHash": "0x2274b4aafb9a877e90483cb1441e7de8f531bd5044ce6648a7d3ba2921b36e9b",
+      "transactionTime": 7177639,
+      "transactionHash": "0xcc4cdf2e575ca955a7aa8cb2494383001fbf3457d40be54204e4edb69647d648"
+    }
+  },
+  {
+    "type": "EiC1Tgosui5O6ikTFQWrIMeDa2SQdxJZjGSZCjNu-AArVA",
+    "transaction": {
+      "transactionTime": 7177649,
+      "transactionHash": "0x8a435c21fa612f67da8d85e54c4e4de4a04104a9b2d8ae90e4e3fa7a7089b8c3",
+      "transactionTimestamp": 1579761487,
+      "transactionNumber": 813,
+      "anchorFileHash": "QmckxVkH1KUg1srDAAPvw5i74qYRzCvnqL1AJTJcwADEFy",
+      "transactionTimeHash": "0xa1d780d9636436b2be48330d8737bf8b99b5e125c38a381066236bb63e8ec29f"
+    },
+    "operation": {
+      "decodedHeader": {
+        "operation": "update",
+        "alg": "ES256K",
+        "kid": "#primary"
+      },
+      "operationHash": "EiD-NavuJDZn09gZSOFMj5hkVN_pM1bRC-EVTfrvjJFO1g",
+      "decodedOperation": {
+        "signature": "0C_QOVB8eSVC2xhb-LfkCgeIbqsmn85e276LvpWDoR16_Jk5Sv8MF030VxQ9A7ldE2qmiYUrCQzp3Epu0sWILQ",
+        "payload": "eyJkaWRVbmlxdWVTdWZmaXgiOiJFaUMxVGdvc3VpNU82aWtURlFXcklNZURhMlNRZHhKWmpHU1pDak51LUFBclZBIiwicHJldmlvdXNPcGVyYXRpb25IYXNoIjoiRWlDMVRnb3N1aTVPNmlrVEZRV3JJTWVEYTJTUWR4SlpqR1NaQ2pOdS1BQXJWQSIsInBhdGNoZXMiOlt7ImFjdGlvbiI6InJlbW92ZS1wdWJsaWMta2V5cyIsInB1YmxpY0tleXMiOlsiI2VkdiJdfV19",
+        "protected": "eyJvcGVyYXRpb24iOiJ1cGRhdGUiLCJraWQiOiIjcHJpbWFyeSIsImFsZyI6IkVTMjU2SyJ9"
+      },
+      "decodedOperationPayload": {
+        "didUniqueSuffix": "EiC1Tgosui5O6ikTFQWrIMeDa2SQdxJZjGSZCjNu-AArVA",
+        "patches": [
+          {
+            "publicKeys": [
+              "#edv"
+            ],
+            "action": "remove-public-keys"
+          }
+        ],
+        "previousOperationHash": "EiC1Tgosui5O6ikTFQWrIMeDa2SQdxJZjGSZCjNu-AArVA"
+      }
+    },
+    "didUniqueSuffix": "EiC1Tgosui5O6ikTFQWrIMeDa2SQdxJZjGSZCjNu-AArVA"
+  }
+]

--- a/packages/element-lib/src/__tests__/test-utils.js
+++ b/packages/element-lib/src/__tests__/test-utils.js
@@ -68,10 +68,8 @@ const getCreatePayloadForKeyIndex = async (mks, index) => {
 
 const getLastOperation = async (sidetree, didUniqueSuffix) => {
   const operations = await sidetree.db.readCollection(didUniqueSuffix);
-  operations.sort(
-    (o1, o2) => o1.transaction.transactionTime - o2.transaction.transactionTime
-  );
-  const last = operations.pop();
+  const orderedOperations = sidetree.func.getOrderedOperations(operations);
+  const last = orderedOperations.pop();
   return last;
 };
 

--- a/packages/element-lib/src/func/func.spec.js
+++ b/packages/element-lib/src/func/func.spec.js
@@ -7,11 +7,13 @@ const {
   bytes32EnodedMultihashToBase58EncodedMultihash,
   objectToMultihash,
   toFullyQualifiedDidDocument,
+  getOrderedOperations,
 } = require('.');
 const { MnemonicKeySystem } = require('../../index');
 const sidetreeCreatePayload = require('../__tests__/__fixtures__/sidetreeCreatePayload');
 const fullyQualifiedEdvDidDoc = require('../__tests__/__fixtures__/fullyQualifiedEdvDidDoc.json');
 const unqualifiedEdvDidDoc = require('../__tests__/__fixtures__/unqualifiedEdvDidDoc.json');
+const unorderedOperations = require('../__tests__/__fixtures__/unorderedOperations.json');
 
 describe('payloadToHash', () => {
   it('should compute the right encodedHash', async () => {
@@ -84,5 +86,17 @@ describe('toFullyQualifiedDidDocument', () => {
       unqualifiedEdvDidDoc
     );
     expect(fullyQualifiedDidDoc).toEqual(fullyQualifiedEdvDidDoc);
+  });
+});
+
+describe('getOrderedOperations', () => {
+  it('should order a list of operations', async () => {
+    expect(unorderedOperations[0].transaction.transactionNumber).toBe(814);
+    expect(unorderedOperations[1].transaction.transactionNumber).toBe(812);
+    expect(unorderedOperations[2].transaction.transactionNumber).toBe(813);
+    const orderedOperations = getOrderedOperations(unorderedOperations);
+    expect(orderedOperations[0].transaction.transactionNumber).toBe(812);
+    expect(orderedOperations[1].transaction.transactionNumber).toBe(813);
+    expect(orderedOperations[2].transaction.transactionNumber).toBe(814);
   });
 });

--- a/packages/element-lib/src/func/index.js
+++ b/packages/element-lib/src/func/index.js
@@ -147,6 +147,15 @@ const toFullyQualifiedDidDocument = didDocument => {
   return JSON.parse(expanded);
 };
 
+const getOrderedOperations = operations => {
+  const orderedOperations = [...operations];
+  orderedOperations.sort(
+    (op1, op2) =>
+      op1.transaction.transactionNumber - op2.transaction.transactionNumber
+  );
+  return orderedOperations;
+};
+
 module.exports = {
   executeSequentially,
   encodeJson,
@@ -161,4 +170,5 @@ module.exports = {
   bytes32EnodedMultihashToBase58EncodedMultihash,
   objectToMultihash,
   toFullyQualifiedDidDocument,
+  getOrderedOperations,
 };

--- a/packages/element-lib/src/sidetree/resolve/index.js
+++ b/packages/element-lib/src/sidetree/resolve/index.js
@@ -292,7 +292,6 @@ const resolve = sidetree => async (did, justInTime = false) => {
     await sidetree.sync(didUniqueSuffix);
   }
   const operations = await sidetree.db.readCollection(didUniqueSuffix);
-  // eslint-disable-next-line max-len
   operations.sort(
     (op1, op2) =>
       op1.transaction.transactionNumber - op2.transaction.transactionNumber


### PR DESCRIPTION
- fix warning in console: operation key was not always unique
- fixes #153 

before
<img width="1440" alt="Screenshot 2020-01-23 at 14 00 06" src="https://user-images.githubusercontent.com/7913565/72963357-abf73280-3de9-11ea-88b0-90a6e578727f.png">
after
<img width="1440" alt="Screenshot 2020-01-23 at 14 04 15" src="https://user-images.githubusercontent.com/7913565/72963361-adc0f600-3de9-11ea-9d5b-33e8838f6556.png">

