### PR TITLE
Feat/mute 623 clean up blockchain interface

### DIFF
--- a/packages/element-lib/src/__tests__/LatePublishAttack.spec.js
+++ b/packages/element-lib/src/__tests__/LatePublishAttack.spec.js
@@ -75,7 +75,8 @@ describe('LatePublishAttack', () => {
     // Instead of writing the anchorFile to IPFS, we only compute its hash
     anchorFileHash = await sidetree.func.objectToMultihash(anchorFile);
     // Anchor on ethereum
-    await sidetree.blockchain.write(anchorFileHash);
+    const txn = await sidetree.blockchain.write(anchorFileHash);
+    expect(txn).toBeDefined();
   });
 
   it('pretend to transfer', async () => {

--- a/packages/element-lib/src/__tests__/test-utils.js
+++ b/packages/element-lib/src/__tests__/test-utils.js
@@ -3,7 +3,6 @@ const faker = require('faker');
 const element = require('../../index');
 const { encodeJson, decodeJson } = require('../func');
 const { getDidDocumentModel, getCreatePayload } = require('../sidetree/op');
-const resolve = require('../sidetree/resolve');
 
 const getTestSideTree = () => {
   const db = new element.adapters.database.ElementRXDBAdapter({
@@ -50,10 +49,8 @@ const changeKid = (payload, newKid) => {
 };
 
 const getDidDocumentForPayload = async (sidetree, payload, didUniqueSuffix) => {
-  const transaction = await sidetree.batchScheduler.writeNow(payload);
-  await sidetree.syncTransaction(transaction);
-  const didDocument = await resolve(sidetree)(didUniqueSuffix);
-  return didDocument;
+  await sidetree.batchScheduler.writeNow(payload);
+  return sidetree.resolve(didUniqueSuffix, true);
 };
 
 const getCreatePayloadForKeyIndex = async (mks, index) => {
@@ -66,7 +63,9 @@ const getCreatePayloadForKeyIndex = async (mks, index) => {
   return getCreatePayload(didDocumentModel, primaryKey);
 };
 
+// TODO
 const getLastOperation = async (sidetree, didUniqueSuffix) => {
+  await sidetree.sync(didUniqueSuffix);
   const operations = await sidetree.db.readCollection(didUniqueSuffix);
   const orderedOperations = sidetree.func.getOrderedOperations(operations);
   const last = orderedOperations.pop();

--- a/packages/element-lib/src/__tests__/test-utils.js
+++ b/packages/element-lib/src/__tests__/test-utils.js
@@ -63,7 +63,6 @@ const getCreatePayloadForKeyIndex = async (mks, index) => {
   return getCreatePayload(didDocumentModel, primaryKey);
 };
 
-// TODO
 const getLastOperation = async (sidetree, didUniqueSuffix) => {
   await sidetree.sync(didUniqueSuffix);
   const operations = await sidetree.db.readCollection(didUniqueSuffix);
@@ -147,7 +146,6 @@ const updateByActorIndex = async (sidetree, actorIndex) => {
   // FIXME
   // make sure getPreviousOperationHash will hit cache.
   const { didUniqueSuffix } = getActorByIndex(actorIndex);
-  await sidetree.resolve(didUniqueSuffix, true);
   const lastOperation = await getLastOperation(sidetree, didUniqueSuffix);
   const newKey = actor.mks.getKeyForPurpose('primary', 10);
   const newPublicKey = {

--- a/packages/element-lib/src/adapters/blockchain/ethereum/__tests__/blockchain.ethereum.spec.js
+++ b/packages/element-lib/src/adapters/blockchain/ethereum/__tests__/blockchain.ethereum.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 const element = require('../../../../../index');
 
 const config = require('../../../json/config.local.json');
@@ -23,11 +24,13 @@ describe('blockchain.ethereum', () => {
 
     it('can create new contracts on the fly', async () => {
       const accounts = await blockchain.web3.eth.getAccounts();
-      const instance = await blockchain.createNewContract(accounts[0]);
+      // FIXME
+      const instance = await blockchain._createNewContract(accounts[0]);
       expect(blockchain.anchorContractAddress).toBe(instance.address);
     });
   });
 
+  // FIXME
   describe('getBlockchainTime', () => {
     it('should return hash and blocknumber', async () => {
       const result = await blockchain.getBlockchainTime(0);

--- a/packages/element-lib/src/adapters/blockchain/ethereum/__tests__/blockchain.ethereum.spec.js
+++ b/packages/element-lib/src/adapters/blockchain/ethereum/__tests__/blockchain.ethereum.spec.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 const element = require('../../../../../index');
+const utils = require('../utils');
 
 const config = require('../../../json/config.local.json');
 
@@ -23,17 +24,15 @@ describe('blockchain.ethereum', () => {
     });
 
     it('can create new contracts on the fly', async () => {
-      const accounts = await blockchain.web3.eth.getAccounts();
-      // FIXME
+      const accounts = await utils.getAccounts(blockchain.web3);
       const instance = await blockchain._createNewContract(accounts[0]);
       expect(blockchain.anchorContractAddress).toBe(instance.address);
     });
   });
 
-  // FIXME
   describe('getBlockchainTime', () => {
     it('should return hash and blocknumber', async () => {
-      const result = await blockchain.getBlockchainTime(0);
+      const result = await utils.getBlockchainTime(blockchain.web3, 0);
       expect(result.time).toBe(0);
       expect(result.hash).toBeDefined();
     });

--- a/packages/element-lib/src/adapters/blockchain/ethereum/index.js
+++ b/packages/element-lib/src/adapters/blockchain/ethereum/index.js
@@ -186,10 +186,6 @@ class EthereumBlockchain {
     };
   }
 
-  async getCurrentTime() {
-    return this.getBlockchainTime('latest');
-  }
-
   async write(anchorFileHash) {
     await this.resolving;
     const [from] = await getAccounts(this.web3);

--- a/packages/element-lib/src/adapters/blockchain/ethereum/index.js
+++ b/packages/element-lib/src/adapters/blockchain/ethereum/index.js
@@ -51,7 +51,7 @@ class EthereumBlockchain {
     if (options && options.omitTimestamp) {
       return txns;
     }
-    return utils.extendSidetreeTransactionWithTimestamp(txns);
+    return this.extendSidetreeTransactionWithTimestamp(txns);
   }
 
   async getTransactionsBlockNumber(transactionHash) {
@@ -96,7 +96,7 @@ class EthereumBlockchain {
   }
 
   async _createNewContract(fromAddress) {
-    const from = fromAddress || (await utils.getAccounts(this.web3));
+    const from = fromAddress || (await utils.getAccounts(this.web3))[0];
     const instance = await utils.retryWithLatestTransactionCount(
       this.web3,
       this.anchorContract.new,

--- a/packages/element-lib/src/adapters/blockchain/ethereum/index.js
+++ b/packages/element-lib/src/adapters/blockchain/ethereum/index.js
@@ -157,7 +157,7 @@ class EthereumBlockchain {
     return this.extendSidetreeTransactionWithTimestamp(txns);
   }
 
-  async getEthereumTransaction(transactionHash) {
+  async getTransactionsBlockNumber(transactionHash) {
     const transaction = await new Promise((resolve, reject) => {
       this.web3.eth.getTransaction(transactionHash, (err, data) => {
         if (err) {
@@ -166,7 +166,7 @@ class EthereumBlockchain {
         return resolve(data);
       });
     });
-    return transaction;
+    return transaction.blockNumber;
   }
 
   async getBlockchainTime(blockHashOrBlockNumber) {

--- a/packages/element-lib/src/adapters/blockchain/ethereum/index.js
+++ b/packages/element-lib/src/adapters/blockchain/ethereum/index.js
@@ -1,50 +1,8 @@
-const Web3 = require('web3');
-const HDWalletProvider = require('@truffle/hdwallet-provider');
+/* eslint-disable no-underscore-dangle */
 const contract = require('@truffle/contract');
-const {
-  bytes32EnodedMultihashToBase58EncodedMultihash,
-  base58EncodedMultihashToBytes32,
-} = require('../../../func');
+const { base58EncodedMultihashToBytes32 } = require('../../../func');
 const anchorContractArtifact = require('../../../../SimpleSidetreeAnchor.json');
-
-const getWeb3 = ({ mnemonic, hdPath, providerUrl }) => {
-  // eslint-disable-next-line
-  if (typeof window !== 'undefined' && window.web3) {
-    // eslint-disable-next-line
-    return window.web3;
-  }
-  const parts = hdPath.split('/');
-  const accountIndex = parseInt(parts.pop(), 10);
-  const hdPathWithoutAccountIndex = `${parts.join('/')}/`;
-  const provider = new HDWalletProvider(
-    mnemonic,
-    providerUrl,
-    accountIndex,
-    1,
-    hdPathWithoutAccountIndex
-  );
-  return new Web3(provider);
-};
-
-const eventLogToSidetreeTransaction = log => ({
-  transactionTime: log.blockNumber,
-  transactionTimeHash: log.blockHash,
-  transactionHash: log.transactionHash,
-  transactionNumber: log.args.transactionNumber.toNumber(),
-  anchorFileHash: bytes32EnodedMultihashToBase58EncodedMultihash(
-    log.args.anchorFileHash
-  ),
-});
-
-const getAccounts = web3 =>
-  new Promise((resolve, reject) => {
-    web3.eth.getAccounts((err, accounts) => {
-      if (err) {
-        reject(err);
-      }
-      resolve(accounts);
-    });
-  });
+const utils = require('./utils');
 
 class EthereumBlockchain {
   constructor(web3, contractAddress) {
@@ -56,17 +14,19 @@ class EthereumBlockchain {
     if (contractAddress) {
       this.anchorContractAddress = contractAddress;
     } else {
-      this.resolving = this.createNewContract().then(() => {
+      this.resolving = this._createNewContract().then(() => {
         this.anchorContract.setProvider(this.web3.currentProvider);
       });
     }
   }
 
+  // eslint-disable-next-line class-methods-use-this
   async extendSidetreeTransactionWithTimestamp(txns) {
     return Promise.all(
       txns.map(async txn => ({
         ...txn,
-        transactionTimestamp: (await this.getBlockchainTime(
+        transactionTimestamp: (await utils.getBlockchainTime(
+          this.web3,
           txn.transactionTime
         )).timestamp,
       }))
@@ -79,82 +39,19 @@ class EthereumBlockchain {
     return new Promise(resolve => setTimeout(resolve, 1000));
   }
 
-  async retryWithLatestTransactionCount(method, args, options, maxRetries = 5) {
-    let tryCount = 0;
-    const errors = [];
-    try {
-      return await method(...args, {
-        ...options,
-      });
-    } catch (e) {
-      errors.push(`${e}`);
-      tryCount += 1;
-    }
-    while (tryCount < maxRetries) {
-      try {
-        return method(...args, {
-          ...options,
-          nonce:
-            // eslint-disable-next-line
-            (await this.web3.eth.getTransactionCount(options.from, 'pending')) + tryCount - 1,
-        });
-      } catch (e) {
-        errors.push(`${e}`);
-        tryCount += 1;
-      }
-    }
-    throw new Error(`
-      Could not use method: ${method}.
-      Most likely reason is invalid nonce.
-      See https://ethereum.stackexchange.com/questions/2527
-
-      This interface uses web3, and cannot be parallelized. 
-      Consider using a different HD Path for each node / service / instance.
-
-      ${JSON.stringify(errors, null, 2)}
-      `);
-  }
-
-  async createNewContract(fromAddress) {
-    if (!fromAddress) {
-      // eslint-disable-next-line
-      [fromAddress] = await getAccounts(this.web3);
-    }
-
-    const instance = await this.retryWithLatestTransactionCount(
-      this.anchorContract.new,
-      [],
-      {
-        from: fromAddress,
-        // TODO: Bad hard coded value, use gasEstimate
-        gas: 4712388,
-      }
-    );
-
-    this.anchorContractAddress = instance.address;
-    return instance;
-  }
-
-  async getInstance() {
-    if (!this.instance) {
-      this.instance = await this.anchorContract.at(this.anchorContractAddress);
-    }
-    return this.instance;
-  }
-
   async getTransactions(fromBlock, toBlock, options) {
-    const instance = await this.getInstance();
+    const instance = await this._getInstance();
     const logs = await instance.getPastEvents('Anchor', {
       // TODO: add indexing here...
       // https://ethereum.stackexchange.com/questions/8658/what-does-the-indexed-keyword-do
       fromBlock,
       toBlock: toBlock || 'latest',
     });
-    const txns = logs.map(eventLogToSidetreeTransaction);
+    const txns = logs.map(utils.eventLogToSidetreeTransaction);
     if (options && options.omitTimestamp) {
       return txns;
     }
-    return this.extendSidetreeTransactionWithTimestamp(txns);
+    return utils.extendSidetreeTransactionWithTimestamp(txns);
   }
 
   async getTransactionsBlockNumber(transactionHash) {
@@ -169,30 +66,14 @@ class EthereumBlockchain {
     return transaction.blockNumber;
   }
 
-  async getBlockchainTime(blockHashOrBlockNumber) {
-    const block = await new Promise((resolve, reject) => {
-      this.web3.eth.getBlock(blockHashOrBlockNumber, (err, data) => {
-        if (err) {
-          return reject(err);
-        }
-        return resolve(data);
-      });
-    });
-    const unPrefixedBlockhash = block.hash.replace('0x', '');
-    return {
-      time: block.number,
-      timestamp: block.timestamp,
-      hash: unPrefixedBlockhash,
-    };
-  }
-
   async write(anchorFileHash) {
     await this.resolving;
-    const [from] = await getAccounts(this.web3);
-    const instance = await this.getInstance();
+    const [from] = await utils.getAccounts(this.web3);
+    const instance = await this._getInstance();
     const bytes32EncodedHash = base58EncodedMultihashToBytes32(anchorFileHash);
     try {
-      const receipt = await this.retryWithLatestTransactionCount(
+      const receipt = await utils.retryWithLatestTransactionCount(
+        this.web3,
         instance.anchorHash,
         [bytes32EncodedHash],
         {
@@ -200,11 +81,34 @@ class EthereumBlockchain {
           gasPrice: '100000000000',
         }
       );
-      return eventLogToSidetreeTransaction(receipt.logs[0]);
+      return utils.eventLogToSidetreeTransaction(receipt.logs[0]);
     } catch (e) {
       console.log(e);
       return null;
     }
+  }
+
+  async _getInstance() {
+    if (!this.instance) {
+      this.instance = await this.anchorContract.at(this.anchorContractAddress);
+    }
+    return this.instance;
+  }
+
+  async _createNewContract(fromAddress) {
+    const from = fromAddress || (await utils.getAccounts(this.web3));
+    const instance = await utils.retryWithLatestTransactionCount(
+      this.web3,
+      this.anchorContract.new,
+      [],
+      {
+        from,
+        // TODO: Bad hard coded value, use gasEstimate
+        gas: 4712388,
+      }
+    );
+    this.anchorContractAddress = instance.address;
+    return instance;
   }
 }
 
@@ -214,7 +118,7 @@ const configure = ({
   providerUrl,
   anchorContractAddress,
 }) => {
-  const web3 = getWeb3({ mnemonic, hdPath, providerUrl });
+  const web3 = utils.getWeb3({ mnemonic, hdPath, providerUrl });
   return new EthereumBlockchain(web3, anchorContractAddress);
 };
 

--- a/packages/element-lib/src/adapters/blockchain/ethereum/utils.js
+++ b/packages/element-lib/src/adapters/blockchain/ethereum/utils.js
@@ -1,0 +1,113 @@
+const Web3 = require('web3');
+const HDWalletProvider = require('@truffle/hdwallet-provider');
+const {
+  bytes32EnodedMultihashToBase58EncodedMultihash,
+} = require('../../../func');
+
+const getWeb3 = ({ mnemonic, hdPath, providerUrl }) => {
+  // eslint-disable-next-line
+  if (typeof window !== 'undefined' && window.web3) {
+    // eslint-disable-next-line
+    return window.web3;
+  }
+  const parts = hdPath.split('/');
+  const accountIndex = parseInt(parts.pop(), 10);
+  const hdPathWithoutAccountIndex = `${parts.join('/')}/`;
+  const provider = new HDWalletProvider(
+    mnemonic,
+    providerUrl,
+    accountIndex,
+    1,
+    hdPathWithoutAccountIndex
+  );
+  return new Web3(provider);
+};
+
+const getAccounts = web3 =>
+  new Promise((resolve, reject) => {
+    web3.eth.getAccounts((err, accounts) => {
+      if (err) {
+        reject(err);
+      }
+      resolve(accounts);
+    });
+  });
+
+const eventLogToSidetreeTransaction = log => ({
+  transactionTime: log.blockNumber,
+  transactionTimeHash: log.blockHash,
+  transactionHash: log.transactionHash,
+  transactionNumber: log.args.transactionNumber.toNumber(),
+  anchorFileHash: bytes32EnodedMultihashToBase58EncodedMultihash(
+    log.args.anchorFileHash
+  ),
+});
+
+const retryWithLatestTransactionCount = async (
+  web3,
+  method,
+  args,
+  options,
+  maxRetries = 5
+) => {
+  let tryCount = 0;
+  const errors = [];
+  try {
+    return await method(...args, {
+      ...options,
+    });
+  } catch (e) {
+    errors.push(`${e}`);
+    tryCount += 1;
+  }
+  while (tryCount < maxRetries) {
+    try {
+      return method(...args, {
+        ...options,
+        nonce:
+          // eslint-disable-next-line
+          (await web3.eth.getTransactionCount(options.from, 'pending')) +
+          tryCount -
+          1,
+      });
+    } catch (e) {
+      errors.push(`${e}`);
+      tryCount += 1;
+    }
+  }
+  throw new Error(`
+    Could not use method: ${method}.
+    Most likely reason is invalid nonce.
+    See https://ethereum.stackexchange.com/questions/2527
+
+    This interface uses web3, and cannot be parallelized. 
+    Consider using a different HD Path for each node / service / instance.
+
+    ${JSON.stringify(errors, null, 2)}
+    `);
+};
+
+const getBlockchainTime = async (web3, blockHashOrBlockNumber) => {
+  const block = await new Promise((resolve, reject) => {
+    web3.eth.getBlock(blockHashOrBlockNumber, (err, data) => {
+      if (err) {
+        return reject(err);
+      }
+      return resolve(data);
+    });
+  });
+  const unPrefixedBlockhash = block.hash.replace('0x', '');
+  return {
+    time: block.number,
+    timestamp: block.timestamp,
+    hash: unPrefixedBlockhash,
+  };
+};
+
+module.exports = {
+  getWeb3,
+  getAccounts,
+  eventLogToSidetreeTransaction,
+  retryWithLatestTransactionCount,
+  getBlockchainTime,
+};

--- a/packages/element-lib/src/crypto/Needham-Schroeder/Needham-Schroeder.spec.js
+++ b/packages/element-lib/src/crypto/Needham-Schroeder/Needham-Schroeder.spec.js
@@ -23,7 +23,6 @@ const addRSAKey = async actor => {
   // eslint-disable-next-line
   actor.key = key;
   const { didUniqueSuffix } = actor;
-  await sidetree.resolve(didUniqueSuffix, true);
   const lastOperation = await getLastOperation(sidetree, didUniqueSuffix);
   const payload = {
     didUniqueSuffix: lastOperation.didUniqueSuffix,

--- a/packages/element-lib/src/sidetree/batch/batchWrite.spec.js
+++ b/packages/element-lib/src/sidetree/batch/batchWrite.spec.js
@@ -1,5 +1,4 @@
 const batchWrite = require('./batchWrite');
-const resolve = require('../resolve');
 const {
   getTestSideTree,
   getCreatePayloadForKeyIndex,
@@ -61,13 +60,12 @@ describe('batchWrite with one operation', () => {
   });
 
   it('should not return the did before sync is called', async () => {
-    const didDocument = await resolve(sidetree)(didUniqueSuffix);
+    const didDocument = await sidetree.resolve(didUniqueSuffix, false);
     expect(didDocument).not.toBeDefined();
   });
 
   it('should resolve the did when the observer synced the transaction', async () => {
-    await sidetree.syncTransaction(transaction);
-    const didDocument = await resolve(sidetree)(didUniqueSuffix);
+    const didDocument = await sidetree.resolve(didUniqueSuffix, true);
     const did = `did:elem:${didUniqueSuffix}`;
     expect(didDocument.id).toBe(did);
     const decodedPayload = decodeJson(createPayload.payload);
@@ -130,15 +128,14 @@ describe('batchWrite with several operations', () => {
   });
 
   it('should not return the did before sync is called', async () => {
-    const didDocument1 = await resolve(sidetree)(didUniqueSuffix1);
+    const didDocument1 = await sidetree.resolve(didUniqueSuffix1, false);
     expect(didDocument1).not.toBeDefined();
-    const didDocument2 = await resolve(sidetree)(didUniqueSuffix2);
+    const didDocument2 = await sidetree.resolve(didUniqueSuffix2, false);
     expect(didDocument2).not.toBeDefined();
   });
 
   it('should resolve the first did when the observer synced the transaction', async () => {
-    await sidetree.syncTransaction(transaction);
-    const didDocument = await resolve(sidetree)(didUniqueSuffix1);
+    const didDocument = await sidetree.resolve(didUniqueSuffix1, true);
     const did = `did:elem:${didUniqueSuffix1}`;
     expect(didDocument.id).toBe(did);
     const decodedPayload = decodeJson(createPayload1.payload);
@@ -154,7 +151,7 @@ describe('batchWrite with several operations', () => {
   });
 
   it('should resolve the second did when the observer synced the transaction', async () => {
-    const didDocument = await resolve(sidetree)(didUniqueSuffix2);
+    const didDocument = await sidetree.resolve(didUniqueSuffix2, true);
     const did = `did:elem:${didUniqueSuffix2}`;
     expect(didDocument.id).toBe(did);
     const decodedPayload = decodeJson(createPayload2.payload);

--- a/packages/element-lib/src/sidetree/resolve/patches.spec.js
+++ b/packages/element-lib/src/sidetree/resolve/patches.spec.js
@@ -32,7 +32,6 @@ describe('patches', () => {
     didUniqueSuffix = await sidetree.func.getDidUniqueSuffix(createPayload);
     did = `did:elem${didUniqueSuffix}`;
     await sidetree.batchScheduler.writeNow(createPayload);
-    await sidetree.sync(didUniqueSuffix);
   });
 
   it('should add a new key', async () => {

--- a/packages/element-lib/src/sidetree/resolve/patches.spec.js
+++ b/packages/element-lib/src/sidetree/resolve/patches.spec.js
@@ -6,6 +6,8 @@ const { MnemonicKeySystem } = require('../../../index');
 
 const sidetree = getTestSideTree();
 
+jest.setTimeout(10 * 1000);
+
 describe('patches', () => {
   let mks;
   let primaryKey;
@@ -29,10 +31,8 @@ describe('patches', () => {
     );
     didUniqueSuffix = await sidetree.func.getDidUniqueSuffix(createPayload);
     did = `did:elem${didUniqueSuffix}`;
-    const createTransaction = await sidetree.batchScheduler.writeNow(
-      createPayload
-    );
-    await sidetree.syncTransaction(createTransaction);
+    await sidetree.batchScheduler.writeNow(createPayload);
+    await sidetree.sync(didUniqueSuffix);
   });
 
   it('should add a new key', async () => {

--- a/packages/element-lib/src/sidetree/utils/transactions.js
+++ b/packages/element-lib/src/sidetree/utils/transactions.js
@@ -12,7 +12,7 @@ const getTransactions = sidetree => async ({ limit } = {}) => {
 };
 
 const getTransactionSummary = sidetree => async transactionHash => {
-  const { blockNumber } = await sidetree.blockchain.getEthereumTransaction(
+  const blockNumber = await sidetree.blockchain.getTransactionsBlockNumber(
     transactionHash
   );
   const transactions = await sidetree.blockchain.getTransactions(


### PR DESCRIPTION
https://transmute.atlassian.net/browse/MUTE-623

- separating public methods in the blockchain interface from utils method
- cleanup the use of syncTransaction
- Rename getEthereumTransaction method