### PR TITLE
Implement mapSync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.1](https://github.com/decentralized-identity/element/compare/v0.8.0...v0.8.1) (2020-05-12)
+
+
+### Bug Fixes
+
+* logging the startBlock and endblock during mapSync ([3136def](https://github.com/decentralized-identity/element/commit/3136def3dc74a2472573607d08d6a019d8702ba5))
+
+
+
+
+
 # [0.8.0](https://github.com/decentralized-identity/element/compare/v0.7.4...v0.8.0) (2020-05-12)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.8.0](https://github.com/decentralized-identity/element/compare/v0.7.4...v0.8.0) (2020-05-12)
+
+
+### Features
+
+* add startBlock and getBlockchainHeight to blockchain adapter ([ea6fdc7](https://github.com/decentralized-identity/element/commit/ea6fdc738b1a124907faaa8dabc8d66a36754e5c))
+* implement mapSync ([3a55f3f](https://github.com/decentralized-identity/element/commit/3a55f3ff16a68f70919bc3d0742cd85a7e13cd5b))
+
+
+
+
+
 ## [0.7.4](https://github.com/decentralized-identity/element/compare/v0.7.3...v0.7.4) (2020-05-11)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.4",
+  "version": "0.8.0",
   "packages": [
     "packages/element-api",
     "packages/element-app",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0",
+  "version": "0.8.1",
   "packages": [
     "packages/element-api",
     "packages/element-app",

--- a/packages/element-api/CHANGELOG.md
+++ b/packages/element-api/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.8.0](https://github.com/decentralized-identity/element/compare/v0.7.4...v0.8.0) (2020-05-12)
+
+**Note:** Version bump only for package @transmute/element-api
+
+
+
+
+
 ## [0.7.4](https://github.com/decentralized-identity/element/compare/v0.7.3...v0.7.4) (2020-05-11)
 
 **Note:** Version bump only for package @transmute/element-api

--- a/packages/element-api/CHANGELOG.md
+++ b/packages/element-api/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.1](https://github.com/decentralized-identity/element/compare/v0.8.0...v0.8.1) (2020-05-12)
+
+**Note:** Version bump only for package @transmute/element-api
+
+
+
+
+
 # [0.8.0](https://github.com/decentralized-identity/element/compare/v0.7.4...v0.8.0) (2020-05-12)
 
 **Note:** Version bump only for package @transmute/element-api

--- a/packages/element-api/package-lock.json
+++ b/packages/element-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmute/element-api",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/element-api/package-lock.json
+++ b/packages/element-api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmute/element-api",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/element-api/package.json
+++ b/packages/element-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmute/element-api",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Node.js REST API For Element / Sidetree Ethereum",
   "author": "Orie Steele",
   "private": true,
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@google-cloud/logging-winston": "^0.10.2",
-    "@transmute/element-lib": "^0.8.0",
+    "@transmute/element-lib": "^0.8.1",
     "base64url": "^3.0.1",
     "cors": "^2.8.5",
     "express": "^4.16.4",

--- a/packages/element-api/package.json
+++ b/packages/element-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmute/element-api",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "description": "Node.js REST API For Element / Sidetree Ethereum",
   "author": "Orie Steele",
   "private": true,
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@google-cloud/logging-winston": "^0.10.2",
-    "@transmute/element-lib": "^0.7.4",
+    "@transmute/element-lib": "^0.8.0",
     "base64url": "^3.0.1",
     "cors": "^2.8.5",
     "express": "^4.16.4",

--- a/packages/element-app/CHANGELOG.md
+++ b/packages/element-app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.8.0](https://github.com/decentralized-identity/element/compare/v0.7.4...v0.8.0) (2020-05-12)
+
+**Note:** Version bump only for package @transmute/element-app
+
+
+
+
+
 ## [0.7.4](https://github.com/decentralized-identity/element/compare/v0.7.3...v0.7.4) (2020-05-11)
 
 

--- a/packages/element-app/CHANGELOG.md
+++ b/packages/element-app/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.1](https://github.com/decentralized-identity/element/compare/v0.8.0...v0.8.1) (2020-05-12)
+
+**Note:** Version bump only for package @transmute/element-app
+
+
+
+
+
 # [0.8.0](https://github.com/decentralized-identity/element/compare/v0.7.4...v0.8.0) (2020-05-12)
 
 **Note:** Version bump only for package @transmute/element-app

--- a/packages/element-app/package-lock.json
+++ b/packages/element-app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmute/element-app",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/element-app/package-lock.json
+++ b/packages/element-app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmute/element-app",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/element-app/package.json
+++ b/packages/element-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmute/element-app",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "private": true,
   "homepage": "https://element-did.com",
   "license": "Apache-2.0",
@@ -8,7 +8,7 @@
     "@material-ui/core": "^4.9.0",
     "@material-ui/icons": "^3.0.2",
     "@transmute/did-wallet": "0.0.0-6",
-    "@transmute/element-lib": "^0.7.4",
+    "@transmute/element-lib": "^0.8.0",
     "ace-builds": "^1.4.11",
     "axios": "^0.18.0",
     "base64url": "^3.0.1",

--- a/packages/element-app/package.json
+++ b/packages/element-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmute/element-app",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "homepage": "https://element-did.com",
   "license": "Apache-2.0",
@@ -8,7 +8,7 @@
     "@material-ui/core": "^4.9.0",
     "@material-ui/icons": "^3.0.2",
     "@transmute/did-wallet": "0.0.0-6",
-    "@transmute/element-lib": "^0.8.0",
+    "@transmute/element-lib": "^0.8.1",
     "ace-builds": "^1.4.11",
     "axios": "^0.18.0",
     "base64url": "^3.0.1",

--- a/packages/element-lib/CHANGELOG.md
+++ b/packages/element-lib/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.1](https://github.com/decentralized-identity/element/compare/v0.8.0...v0.8.1) (2020-05-12)
+
+
+### Bug Fixes
+
+* logging the startBlock and endblock during mapSync ([3136def](https://github.com/decentralized-identity/element/commit/3136def3dc74a2472573607d08d6a019d8702ba5))
+
+
+
+
+
 # [0.8.0](https://github.com/decentralized-identity/element/compare/v0.7.4...v0.8.0) (2020-05-12)
 
 

--- a/packages/element-lib/CHANGELOG.md
+++ b/packages/element-lib/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.8.0](https://github.com/decentralized-identity/element/compare/v0.7.4...v0.8.0) (2020-05-12)
+
+
+### Features
+
+* add startBlock and getBlockchainHeight to blockchain adapter ([ea6fdc7](https://github.com/decentralized-identity/element/commit/ea6fdc738b1a124907faaa8dabc8d66a36754e5c))
+* implement mapSync ([3a55f3f](https://github.com/decentralized-identity/element/commit/3a55f3ff16a68f70919bc3d0742cd85a7e13cd5b))
+
+
+
+
+
 ## [0.7.4](https://github.com/decentralized-identity/element/compare/v0.7.3...v0.7.4) (2020-05-11)
 
 **Note:** Version bump only for package @transmute/element-lib

--- a/packages/element-lib/package-lock.json
+++ b/packages/element-lib/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmute/element-lib",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/element-lib/package-lock.json
+++ b/packages/element-lib/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmute/element-lib",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/element-lib/package.json
+++ b/packages/element-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmute/element-lib",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Experimental Sidetree Protocol based DID Method `elem` with Ethereum and IPFS",
   "main": "index.js",
   "repository": {

--- a/packages/element-lib/package.json
+++ b/packages/element-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@transmute/element-lib",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "description": "Experimental Sidetree Protocol based DID Method `elem` with Ethereum and IPFS",
   "main": "index.js",
   "repository": {

--- a/packages/element-lib/src/__tests__/LatePublishAttack.spec.js
+++ b/packages/element-lib/src/__tests__/LatePublishAttack.spec.js
@@ -29,6 +29,7 @@ afterAll(async () => {
 describe('LatePublishAttack', () => {
   beforeAll(async () => {
     sidetree = await getTestSideTree();
+    sidetree.parameters.mapSync = false;
     await generateActors(sidetree, 1);
     actor = await getActorByIndex(0);
   });

--- a/packages/element-lib/src/__tests__/PoisonedAnchorFileAttack.spec.js
+++ b/packages/element-lib/src/__tests__/PoisonedAnchorFileAttack.spec.js
@@ -11,6 +11,7 @@ let sidetree;
 let actor;
 
 beforeAll(async () => {
+  sidetree.parameters.mapSync = false;
   sidetree = getTestSideTree();
   await sidetree.db.deleteDB();
   await generateActors(sidetree, 1);

--- a/packages/element-lib/src/__tests__/PoisonedAnchorFileAttack.spec.js
+++ b/packages/element-lib/src/__tests__/PoisonedAnchorFileAttack.spec.js
@@ -11,8 +11,8 @@ let sidetree;
 let actor;
 
 beforeAll(async () => {
-  sidetree.parameters.mapSync = false;
   sidetree = getTestSideTree();
+  sidetree.parameters.mapSync = false;
   await sidetree.db.deleteDB();
   await generateActors(sidetree, 1);
   actor = await getActorByIndex(0);

--- a/packages/element-lib/src/__tests__/PoisonedBatchFileAttack.spec.js
+++ b/packages/element-lib/src/__tests__/PoisonedBatchFileAttack.spec.js
@@ -14,6 +14,7 @@ const wrongBatchFileHash = 'QmTJGHccriUtq3qf3bvAQUcDUHnBbHNJG2x2FYwYUecN43';
 
 beforeAll(async () => {
   sidetree = getTestSideTree();
+  sidetree.parameters.mapSync = false;
   await sidetree.db.deleteDB();
   await generateActors(sidetree, 1);
   actor = await getActorByIndex(0);

--- a/packages/element-lib/src/__tests__/PoisonedOperationAttack.spec.js
+++ b/packages/element-lib/src/__tests__/PoisonedOperationAttack.spec.js
@@ -12,6 +12,7 @@ let actor;
 
 beforeAll(async () => {
   sidetree = getTestSideTree();
+  sidetree.parameters.mapSync = false;
   await generateActors(sidetree, 1);
   actor = await getActorByIndex(0);
   await sidetree.batchScheduler.writeNow(actor.createPayload);

--- a/packages/element-lib/src/__tests__/test-utils.js
+++ b/packages/element-lib/src/__tests__/test-utils.js
@@ -31,7 +31,7 @@ const getTestSideTree = () => {
     batchingIntervalInSeconds: 1,
     didMethodName,
     logLevel: 'error',
-    mapSync: true,
+    mapSync: false,
     maxNumberOfBlocksPerSync: 1000,
   };
 

--- a/packages/element-lib/src/__tests__/test-utils.js
+++ b/packages/element-lib/src/__tests__/test-utils.js
@@ -32,6 +32,7 @@ const getTestSideTree = () => {
     didMethodName,
     logLevel: 'error',
     mapSync: true,
+    maxNumberOfBlocksPerSync: 1000,
   };
 
   const sidetree = new element.Sidetree({

--- a/packages/element-lib/src/__tests__/test-utils.js
+++ b/packages/element-lib/src/__tests__/test-utils.js
@@ -31,6 +31,7 @@ const getTestSideTree = () => {
     batchingIntervalInSeconds: 1,
     didMethodName,
     logLevel: 'error',
+    mapSync: true,
   };
 
   const sidetree = new element.Sidetree({

--- a/packages/element-lib/src/adapters/blockchain/ethereum/index.js
+++ b/packages/element-lib/src/adapters/blockchain/ethereum/index.js
@@ -19,6 +19,7 @@ class EthereumBlockchain {
       });
     }
     this.logger = console;
+    this.startBlock = 0;
   }
 
   async extendSidetreeTransactionWithTimestamp(txns) {
@@ -89,6 +90,18 @@ class EthereumBlockchain {
       this.logger.error(e.message);
       return null;
     }
+  }
+
+  async getBlockchainHeight() {
+    const height = await new Promise((resolve, reject) => {
+      this.web3.eth.getBlockNumber((err, data) => {
+        if (err) {
+          return reject(err);
+        }
+        return resolve(data);
+      });
+    });
+    return height;
   }
 
   async _getInstance() {

--- a/packages/element-lib/src/sidetree/batch/BatchScheduler.js
+++ b/packages/element-lib/src/sidetree/batch/BatchScheduler.js
@@ -46,7 +46,7 @@ class BatchScheduler {
       this.sidetree.logger.error(
         'Unexpected and unhandled error during batch writing, investigate and fix:'
       );
-      this.sidetree.logger.error(error);
+      this.sidetree.logger.error(error.message);
     } finally {
       const end = Date.now();
       this.sidetree.logger.info(

--- a/packages/element-lib/src/sidetree/index.js
+++ b/packages/element-lib/src/sidetree/index.js
@@ -1,5 +1,10 @@
 const resolve = require('./resolve');
-const { sync, syncTransaction } = require('./sync');
+const {
+  sync,
+  syncTransaction,
+  mapSync,
+  mapSyncTransaction,
+} = require('./sync');
 const {
   getTransactions,
   getTransactionSummary,
@@ -29,9 +34,11 @@ class Sidetree {
     this.db = db;
     this.op = op(this);
     this.func = func;
-    // Observer
+    // Sync
     this.sync = sync(this);
     this.syncTransaction = syncTransaction(this);
+    this.mapSync = mapSync(this);
+    this.mapSyncTransaction = mapSyncTransaction(this);
     // Resolver
     this.resolve = resolve(this);
     // Batching

--- a/packages/element-lib/src/sidetree/resolve/resolve.spec.js
+++ b/packages/element-lib/src/sidetree/resolve/resolve.spec.js
@@ -540,6 +540,7 @@ describe('resolve just in time', () => {
     let didUniqueSuffix3;
 
     beforeAll(async () => {
+      sidetree.parameters.mapSync = false;
       await sidetree.db.deleteDB();
       // Create a first transaction with two operations
       createPayload1 = await getCreatePayloadForKeyIndex(sidetree, mks, 0);

--- a/packages/element-lib/src/sidetree/sync/index.js
+++ b/packages/element-lib/src/sidetree/sync/index.js
@@ -161,7 +161,7 @@ const mapSyncTransaction = sidetree => async transaction => {
       );
     }, anchorFile.didUniqueSuffixes);
   } catch (e) {
-    sidetree.logger.error(e);
+    sidetree.logger.error(e.message);
   }
 };
 

--- a/packages/element-lib/src/sidetree/sync/index.js
+++ b/packages/element-lib/src/sidetree/sync/index.js
@@ -171,7 +171,7 @@ const mapSync = sidetree => async () => {
     (lastSyncedBlock && lastSyncedBlock.transactionTime) ||
       sidetree.blockchain.startBlock
   );
-  sidetree.logger.info('map sync starting at', startBlock);
+  sidetree.logger.info(`map sync starting at ${startBlock}`);
   const maxNumberOfBlocksPerSync =
     sidetree.parameters.maxNumberOfBlocksPerSync || 100;
   const blockchainHeight = await sidetree.blockchain.getBlockchainHeight();
@@ -187,7 +187,7 @@ const mapSync = sidetree => async () => {
   await sidetree.db.write('mapSyncLastBlock', {
     transactionTime: endBlock,
   });
-  sidetree.logger.info('map synced up to', endBlock);
+  sidetree.logger.info(`map synced up to ${endBlock}`);
 };
 
 module.exports = { syncTransaction, sync, mapSync, mapSyncTransaction };

--- a/packages/element-lib/src/sidetree/sync/index.js
+++ b/packages/element-lib/src/sidetree/sync/index.js
@@ -142,4 +142,52 @@ const sync = sidetree => async (onlyDidUniqueSuffix = null) => {
   }
 };
 
-module.exports = { syncTransaction, sync };
+const mapSyncTransaction = sidetree => async transaction => {
+  try {
+    isTransactionValid(transaction);
+    const anchorFile = await readThenWriteToCache(
+      sidetree,
+      transaction.anchorFileHash
+    );
+    isAnchorFileValid(anchorFile);
+    const { transactionNumber } = transaction;
+    await executeSequentially(uniqueSuffix => {
+      return sidetree.db.write(
+        `transaction:${transactionNumber}:${uniqueSuffix}`,
+        {
+          type: `transactions:${uniqueSuffix}`,
+          transaction,
+        }
+      );
+    }, anchorFile.didUniqueSuffixes);
+  } catch (e) {
+    sidetree.logger.error(e);
+  }
+};
+
+const mapSync = sidetree => async () => {
+  const lastSyncedBlock = await sidetree.db.read('mapSyncLastBlock');
+  const startBlock = Number(
+    (lastSyncedBlock && lastSyncedBlock.transactionTime) ||
+      sidetree.blockchain.startBlock
+  );
+  sidetree.logger.info('map sync starting at', startBlock);
+  const maxNumberOfBlocksPerSync =
+    sidetree.parameters.maxNumberOfBlocksPerSync || 100;
+  const blockchainHeight = await sidetree.blockchain.getBlockchainHeight();
+  let endBlock = Number(startBlock) + maxNumberOfBlocksPerSync;
+  endBlock = Math.min(endBlock, blockchainHeight);
+  const transactions = await sidetree.blockchain.getTransactions(
+    startBlock,
+    endBlock,
+    { omitTimestamp: true }
+  );
+  sidetree.logger.info(`found ${transactions.length} transactions`);
+  await executeSequentially(t => sidetree.mapSyncTransaction(t), transactions);
+  await sidetree.db.write('mapSyncLastBlock', {
+    transactionTime: endBlock,
+  });
+  sidetree.logger.info('map synced up to', endBlock);
+};
+
+module.exports = { syncTransaction, sync, mapSync, mapSyncTransaction };


### PR DESCRIPTION
- Implemented mapSync: another way of syncing Blockchain transactions that only require each Blockchain transaction to be processed once:
The sync will build a map of (didUniqueSuffix -> [list of related Sidetree transactions]), then will download the batch file of each transaction **at resolve time** to get the operations necessary to build the did document